### PR TITLE
feat: supporting args as an array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,10 @@ module.exports = {
   inspect: inspect,
 };
 
+module.exports.__tests = {
+  buildArgs: buildArgs,
+};
+
 function inspect(root, targetFile, options) {
   if (!options) { options = { dev: false }; }
   return subProcess.execute('sbt',
@@ -38,7 +42,7 @@ function inspect(root, targetFile, options) {
 function buildArgs(root, targetFile, sbtArgs) {
   var args = ['dependency-tree'];
   if (sbtArgs) {
-    args.push(sbtArgs);
+    args = args.concat(sbtArgs);
   }
   return args;
 }

--- a/test/functional/sbt-plugin.test.js
+++ b/test/functional/sbt-plugin.test.js
@@ -1,0 +1,24 @@
+var test = require('tap-only');
+var plugin = require('../../lib').__tests;
+
+test('check build args with array', function (t) {
+  var result = plugin.buildArgs(null, null, [
+    '-Paxis',
+    '-Pjaxen',
+  ]);
+  t.deepEqual(result, [
+    'dependency-tree',
+    '-Paxis',
+    '-Pjaxen',
+  ]);
+  t.end();
+});
+
+test('check build args with string', function (t) {
+  var result = plugin.buildArgs(null, null, '-Paxis -Pjaxen');
+  t.deepEqual(result, [
+    'dependency-tree',
+    '-Paxis -Pjaxen',
+  ]);
+  t.end();
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Double-dash arguments are now sent as an array of strings, split by spaces.
Supports older, string-string arguments as well, so no breaking change here.