### PR TITLE
chore: debug sbt errors according to -d flag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,9 @@ function inspect(root, targetFile, options) {
     };
   })
   .catch(function (error) {
+    if (options._.debug) {
+      console.error(error);
+    }
     var thrownError = parser.parseError(error);
     if (thrownError) {
       throw thrownError;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds a logging of sbt errors when running with the debug (`-d`) flag.