### PR TITLE
fix: pass argument to `sbt` before task name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,9 +42,10 @@ function inspect(root, targetFile, options) {
 }
 
 function buildArgs(root, targetFile, sbtArgs) {
-  var args = ['dependencyTree'];
+  var args = [];
   if (sbtArgs) {
     args = args.concat(sbtArgs);
   }
+  args.push('dependencyTree');
   return args;
 }

--- a/test/functional/sbt-plugin.test.js
+++ b/test/functional/sbt-plugin.test.js
@@ -7,9 +7,9 @@ test('check build args with array', function (t) {
     '-Pjaxen',
   ]);
   t.deepEqual(result, [
-    'dependencyTree',
     '-Paxis',
     '-Pjaxen',
+    'dependencyTree',
   ]);
   t.end();
 });
@@ -17,8 +17,8 @@ test('check build args with array', function (t) {
 test('check build args with string', function (t) {
   var result = plugin.buildArgs(null, null, '-Paxis -Pjaxen');
   t.deepEqual(result, [
-    'dependencyTree',
     '-Paxis -Pjaxen',
+    'dependencyTree',
   ]);
   t.end();
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

This fixes an issues where arguments passed to the `snyk` cli after a `--` are not making it through in any useful way to `sbt`.

Arguments to configure the environment, e.g. -Dsbt.log.noformat=true, are ignored when passed after the `dependencyTree` task name.
