### PR TITLE
fix: force no formatting on sbt output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function inspect(root, targetFile, options) {
 }
 
 function buildArgs(root, targetFile, sbtArgs) {
-  var args = [];
+  var args = ['-Dsbt.log.noformat=true']; // force plain output
   if (sbtArgs) {
     args = args.concat(sbtArgs);
   }

--- a/test/functional/sbt-plugin.test.js
+++ b/test/functional/sbt-plugin.test.js
@@ -7,6 +7,7 @@ test('check build args with array', function (t) {
     '-Pjaxen',
   ]);
   t.deepEqual(result, [
+    '-Dsbt.log.noformat=true',
     '-Paxis',
     '-Pjaxen',
     'dependencyTree',
@@ -17,6 +18,7 @@ test('check build args with array', function (t) {
 test('check build args with string', function (t) {
   var result = plugin.buildArgs(null, null, '-Paxis -Pjaxen');
   t.deepEqual(result, [
+    '-Dsbt.log.noformat=true',
     '-Paxis -Pjaxen',
     'dependencyTree',
   ]);


### PR DESCRIPTION
When the system property sbt.log.noformat is not set to true, `sbt` generates color-enabled output, which breaks the plugin's parsing logic. Forcing sbt.log.noformat to true to enable plain output by default.
