### PR TITLE
snyk: append the error text to thrown errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,11 +33,15 @@ function inspect(root, targetFile, options) {
   })
   .catch(function (error) {
     debug(error);
-    var thrownError = parser.parseError(error);
-    if (thrownError) {
-      throw thrownError;
+    if (typeof error == 'string') {
+      var thrownError = parser.parseError(error);
+      if (thrownError) {
+        throw thrownError;
+      }
+      throw new Error('snyk-sbt-plugin error: ' + error);
     }
-    throw new Error('An unknown error occurred.');
+
+    throw error;
   });
 }
 

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -27,6 +27,7 @@ test('run inspect() with no sbt plugin', function (t) {
     t.fail('should not be reached');
   })
   .catch(function (result) {
+    t.match(result.message, 'Missing plugin `sbt-dependency-graph`');
     t.pass('Error thrown correctly');
   });
 });


### PR DESCRIPTION
instead of current 'An unknown error occurred.' when e.g. `sbt` is not in the PATH
