### PR TITLE
fix: throw proper error on failing sbt execution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@ var path = require('path');
 var subProcess = require('./sub-process');
 var parser = require('./parse-sbt');
 var packageFormatVersion = 'mvn:0.0.1';
-var debug = require('debug')('snyk');
 
 module.exports = {
   inspect: inspect,
@@ -16,9 +15,8 @@ function inspect(root, targetFile, options) {
   if (!options) {
     options = {dev: false};
   }
-  return subProcess.execute('sbt',
-    buildArgs(root, targetFile, options.args),
-    {cwd: root})
+  var sbtArgs = buildArgs(root, targetFile, options.args);
+  return subProcess.execute('sbt', sbtArgs, {cwd: root})
     .then(function (result) {
       var packageName = path.basename(root);
       var packageVersion = '0.0.0';
@@ -34,15 +32,14 @@ function inspect(root, targetFile, options) {
       };
     })
     .catch(function (error) {
-      debug(error);
-      if (typeof error == 'string') {
-        var thrownError = parser.parseError(error);
-        if (thrownError) {
-          throw thrownError;
-        }
-        throw new Error('snyk-sbt-plugin error: ' + error);
-      }
-
+      error.message = error.message + '\n\n' +
+        'Please make sure that the `sbt-dependency-graph` plugin ' +
+        '(https://github.com/jrudolph/sbt-dependency-graph) is installed ' +
+        'globally or on the current project, and that ' +
+        '`sbt ' + sbtArgs.join(' ') + '` executes successfully ' +
+        'on this project.\n\n' +
+        'If the problem persists, collect the output of ' +
+        '`sbt ' + sbtArgs.join(' ') + '` and contact support@snyk.io\n';
       throw error;
     });
 }

--- a/lib/parse-sbt.js
+++ b/lib/parse-sbt.js
@@ -81,14 +81,6 @@ function convertDepArrayToObject(depsArr) {
   }, {});
 }
 
-function parseError(text) {
-  if (text.indexOf('Not a valid command: dependencyTree') !== -1) {
-    return new Error('Error: Missing plugin `sbt-dependency-graph` ' +
-      '(https://github.com/jrudolph/sbt-dependency-graph).\n' +
-      'Please install it globally or on the current project and try again.');
-  }
-}
-
 function parse(text, name, version) {
   var rootTree = convertStrToTree(text);
   var snykTree;
@@ -119,7 +111,6 @@ function parse(text, name, version) {
 
 module.exports = {
   parse: parse,
-  parseError: parseError,
 };
 
 function getKeys(obj) {

--- a/lib/sub-process.js
+++ b/lib/sub-process.js
@@ -20,7 +20,7 @@ module.exports.execute = function (command, args, options) {
 
     proc.on('close', function (code) {
       if (code !== 0) {
-        return reject(stdout || stderr);
+        return reject(new Error(stdout || stderr));
       }
       resolve(stdout || stderr);
     });

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
-  "dependencies": {
-    "debug": "^3.1.0"
-  },
   "devDependencies": {
     "eslint": "^4.11.0",
     "semantic-release": "^15",

--- a/test/fixtures/sbt-no-plugin-output.txt
+++ b/test/fixtures/sbt-no-plugin-output.txt
@@ -1,8 +1,0 @@
-[info] Loading global plugins from /Users/dror/.sbt/0.13/plugins/project
-[info] Loading global plugins from /Users/dror/.sbt/0.13/plugins
-[info] Loading project definition from /Users/dror/work/snyk/snyk-sbt-plugin/test/fixtures/testproj-noplugin/project
-[info] Set current project to Hello (in build file:/Users/dror/work/snyk/snyk-sbt-plugin/test/fixtures/testproj-noplugin/)
-[error] Not a valid command: dependencyTree
-[error] Not a valid key: dependencyTree (similar: dependency-overrides, dependencyOverrides, dependency-classpath)
-[error] dependencyTree
-[error]                ^

--- a/test/functional/parse-sbt.test.js
+++ b/test/functional/parse-sbt.test.js
@@ -77,12 +77,3 @@ test('parse `sbt dependencies` output: single configuration', function (t) {
     .dependencies['joda-time:joda-time'].version,
   '2.5', 'transient dependency');
 });
-
-
-test('parse an error output', function (t) {
-  t.plan(1);
-  var sbtOutput = fs.readFileSync(path.join(
-    __dirname, '..', 'fixtures', 'sbt-no-plugin-output.txt'), 'utf8');
-  var error = parser.parseError(sbtOutput, 'testApp', '1.0.1');
-  t.type(error, 'object', 'Error thrown correctly');
-});

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -1,6 +1,8 @@
 var path = require('path');
 var test = require('tap-only');
+var sinon = require('sinon');
 var plugin = require('../../lib');
+var subProcess = require('../../lib/sub-process');
 
 test('run inspect()', function (t) {
   return plugin.inspect(path.join(
@@ -23,8 +25,30 @@ test('run inspect() with no sbt plugin', function (t) {
     .then(function () {
       t.fail('should not be reached');
     })
-    .catch(function (result) {
-      t.match(result.message, 'Missing plugin `sbt-dependency-graph`');
+    .catch(function (error) {
+      t.match(error.message, 'the `sbt-dependency-graph` plugin');
       t.pass('Error thrown correctly');
     });
 });
+
+test('run inspect() with failing `sbt` execution', function (t) {
+  stubSubProcessExec(t);
+  return plugin.inspect(path.join(__dirname, '..', 'fixtures', 'testproj'),
+    'build.sbt')
+    .then(function () {
+      t.fail('should not be reached');
+    })
+    .catch(function (error) {
+      t.match(error.message, 'abort');
+      t.pass('Error thrown correctly');
+    });
+});
+
+
+function stubSubProcessExec(t) {
+  sinon.stub(subProcess, 'execute')
+    .callsFake(function () {
+      return Promise.reject(new Error('abort'));
+    });
+  t.teardown(subProcess.execute.restore);
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

When `sbt` execution ends with an error, the plugin used to reject with a string containing the stdout or stderr of the `sbt` process. This doesn't work well with the CLI, which expects proper `Error` objects on plugin failure. Now fixed!