### PR TITLE
BREAKING CHANGE: drop unused groupId and artifactId attributes from response

### DIFF
--- a/lib/parse-sbt.js
+++ b/lib/parse-sbt.js
@@ -38,10 +38,7 @@ function walkInTree(toNode, fromNode) {
       var externalNode = getPackageNameAndVersion(
         fromNode.children[j].data);
       if (externalNode) {
-        var coords = externalNode.name.split(':');
         var newNode = {
-          groupId: coords[0],
-          artifactId: coords[1],
           version: externalNode.version,
           name: externalNode.name,
           dependencies: [],


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- removes unused `groupId` and `artifactId` from response

#### Any background context you want to provide?

- the current dependency tree format is very verbose and this gives us a tiny bit more headroom for large projects
