### PR TITLE
Fix/path to target file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,9 @@ function inspect(root, targetFile, options) {
   if (!options) {
     options = {dev: false};
   }
-  var sbtArgs = buildArgs(root, targetFile, options.args);
-  return subProcess.execute('sbt', sbtArgs, {cwd: root})
+  var sbtArgs = buildArgs(options.args);
+  var targetFilePath = path.dirname(path.resolve(root, targetFile));
+  return subProcess.execute('sbt', sbtArgs, {cwd: targetFilePath})
     .then(function (result) {
       var packageName = path.basename(root);
       var packageVersion = '0.0.0';
@@ -44,7 +45,7 @@ function inspect(root, targetFile, options) {
     });
 }
 
-function buildArgs(root, targetFile, sbtArgs) {
+function buildArgs(sbtArgs) {
   var args = ['-Dsbt.log.noformat=true']; // force plain output
   if (sbtArgs) {
     args = args.concat(sbtArgs);

--- a/test/functional/sbt-plugin.test.js
+++ b/test/functional/sbt-plugin.test.js
@@ -2,7 +2,7 @@ var test = require('tap-only');
 var plugin = require('../../lib').__tests;
 
 test('check build args with array', function (t) {
-  var result = plugin.buildArgs(null, null, [
+  var result = plugin.buildArgs([
     '-Paxis',
     '-Pjaxen',
   ]);
@@ -16,7 +16,7 @@ test('check build args with array', function (t) {
 });
 
 test('check build args with string', function (t) {
-  var result = plugin.buildArgs(null, null, '-Paxis -Pjaxen');
+  var result = plugin.buildArgs('-Paxis -Pjaxen');
   t.deepEqual(result, [
     '-Dsbt.log.noformat=true',
     '-Paxis -Pjaxen',

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -5,9 +5,8 @@ var plugin = require('../../lib');
 var subProcess = require('../../lib/sub-process');
 
 test('run inspect()', function (t) {
-  return plugin.inspect(path.join(
-    __dirname, '..', 'fixtures', 'testproj'),
-  'build.sbt')
+  return plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+    'testproj/build.sbt')
     .then(function (result) {
       t.equal(result.package
         .dependencies['axis:axis']
@@ -33,8 +32,8 @@ test('run inspect() with no sbt plugin', function (t) {
 
 test('run inspect() with failing `sbt` execution', function (t) {
   stubSubProcessExec(t);
-  return plugin.inspect(path.join(__dirname, '..', 'fixtures', 'testproj'),
-    'build.sbt')
+  return plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+    'testproj/build.sbt')
     .then(function () {
       t.fail('should not be reached');
     })


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The plugin used to disregard the target file path, so calling `inspect('path/to/project', 'path/to/buildfile/in/project', options)` would fail.

Fixed by running `sbt` in the full path leading to the target file.