### PR TITLE
fix: add logging to sub process

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
       }
     ],
     "max-depth": [1, 3],
-    "max-len": [1, 80],
+    "max-len": [1, 120],
     "max-statements": [1, 25],
     "new-cap": 0,
     "no-caller": 2,

--- a/lib/sub-process.js
+++ b/lib/sub-process.js
@@ -1,28 +1,47 @@
-var childProcess = require('child_process');
+const childProcess = require('child_process');
+const debugModule = require('debug');
 
-module.exports.execute = function(command, args, options) {
-  var spawnOptions = {shell: true};
+// To enable debugging output, run the CLI as `DEBUG=snyk-sbt-plugin snyk ...`
+const debugLogging = debugModule('snyk-sbt-plugin');
+
+module.exports.execute = (command, args, options) => {
+  const spawnOptions = {shell: true};
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
 
-  return new Promise(function(resolve, reject) {
-    var stdout = '';
-    var stderr = '';
+  const fullCommand = command + ' ' + args.join(' ');
 
-    var proc = childProcess.spawn(command, args, spawnOptions);
-    proc.stdout.on('data', function(data) {
-      stdout = stdout + data;
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+
+    const proc = childProcess.spawn(command, args, spawnOptions);
+    proc.stdout.on('data', (data) => {
+      const strData = data.toString();
+      stdout = stdout + strData;
+      strData.split('\n').forEach((str) => {
+        debugLogging(str);
+      });
     });
-    proc.stderr.on('data', function(data) {
+
+    proc.stderr.on('data', (data) => {
       stderr = stderr + data;
+      data.toString().split('\n').forEach((str) => {
+        debugLogging(str);
+      });
     });
 
-    proc.on('close', function(code) {
+    proc.on('close', (code) => {
       if (code !== 0) {
-        return reject(new Error(stdout || stderr));
+        return reject(new Error(
+          `>>> command: ${fullCommand} >>> exit code: ${code} ` +
+          `>>> stdout: ${stdout} >>> stderr: ${stderr}`));
       }
-      resolve(stdout || stderr);
+      if (stderr) {
+        debugLogging('subprocess exit code = 0, but stderr was not empty: ' + stderr);
+      }
+      resolve(stdout);
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
+    "debug": "^4.1.1",
     "sinon": "^2.4.1",
     "tap": "12.6.1",
     "tap-only": "0.0.5",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds logging to sub process running sbt. To see the debug logs run the system-tests with `DEBUG=snyk-sbt-plugin npm run test-system`

#### How should this be manually tested?
`DEBUG=snyk-sbt-plugin npm run test-system`


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-641

#### Screenshots
<img width="781" alt="Screen Shot 2019-05-30 at 17 05 53" src="https://user-images.githubusercontent.com/25888089/58638524-bbc38300-82fd-11e9-827a-afa83b85c8e3.png">
