### PR TITLE
feat: add a debug warning if manifest is missing on disk

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -46,6 +46,9 @@ export async function inspect(root, targetFile, options): Promise<types.PluginRe
 
 async function legacyInspect(root: string, targetFile: string, options: any) {
   const targetFilePath = path.dirname(path.resolve(root, targetFile));
+  if (!fs.existsSync(targetFilePath)) {
+    debug(`build.sbt not found at location: ${targetFilePath}. This may result in no dependencies`);
+  }
   const detectedCoursier = coursierPluginInProject(targetFilePath);
   let useCoursier = detectedCoursier;
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- Check a file exists before passing it to sub process as otherwise it fails inside the process without a nice error