### PR TITLE
fix: quit if process requires input

### DIFF
--- a/lib/sub-process.js
+++ b/lib/sub-process.js
@@ -23,6 +23,12 @@ module.exports.execute = (command, args, options) => {
       strData.split('\n').forEach((str) => {
         debugLogging(str);
       });
+      if (strData.includes('(q)uit')) {
+        proc.stdin.setEncoding('utf-8');
+        proc.stdin.write('q\n');
+        debugLogging('sbt is requiring input. Provided (q)uit signal. ' +
+          'There is no current workaround for this, see: https://stackoverflow.com/questions/21484166');
+      }
     });
 
     proc.stderr.on('data', (data) => {
@@ -34,9 +40,11 @@ module.exports.execute = (command, args, options) => {
 
     proc.on('close', (code) => {
       if (code !== 0) {
-        return reject(new Error(
-          `>>> command: ${fullCommand} >>> exit code: ${code} ` +
-          `>>> stdout: ${stdout} >>> stderr: ${stderr}`));
+        return reject(new Error(`
+>>> command: ${fullCommand}
+>>> exit code: ${code}
+>>> stdout: ${stdout}
+>>> stderr: ${stderr || 'null'}`));
       }
       if (stderr) {
         debugLogging('subprocess exit code = 0, but stderr was not empty: ' + stderr);

--- a/test/fixtures/bad-project/build.sbt
+++ b/test/fixtures/bad-project/build.sbt
@@ -1,0 +1,5 @@
+import sbttalon., TalonVersions.
+
+thriftFlavor in ThisBuild := sbttalon.Apache
+
+lazy val commonSettings = Seq(organization in ThisBuild := "com.project",name in ThisBuild := "claim-service",version in ThisBuild := "1.0.0")

--- a/test/fixtures/bad-project/project/build.properties
+++ b/test/fixtures/bad-project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.17

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -72,6 +72,17 @@ test('run inspect() with commented out coursier on 0.13', async (t) => {
   'correct version found');
 });
 
+test('run inspect() on bad project requiring user input', async (t) => {
+  try {
+    await plugin.inspect(path.join(__dirname, '..', 'fixtures', 'bad-project'), 'build.sbt');
+    t.fail('Expected to fail');
+  } catch (error) {
+    t.match(error.message, 'code: 1');
+    t.match(error.message, '(q)uit');
+    t.pass('Error thrown correctly');
+  }
+});
+
 test('run inspect() with failing `sbt` execution', async (t) => {
   stubSubProcessExec(t);
   try {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
If sbt doesn't know how to handle an issue, it will ask for user input. Snyk doesn't know what the correct solution is, so we quit the process, and output it to the user.

SBT output looks like this when it hangs:
```[info] Loading project definition from /Users/orsagie/snyk/snyk-sbt-plugin/test/fixtures/bad-project/project
[error] [/Users/orsagie/snyk/snyk-sbt-plugin/test/fixtures/bad-project/build.sbt]:1: identifier expected but ',' found.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```
