### PR TITLE
fix: have no timeout by default

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -4,8 +4,9 @@ import * as debugModule from 'debug';
 
 // To enable debugging output, run the CLI as `DEBUG=snyk-sbt-plugin snyk ...`
 const debugLogging = debugModule('snyk-sbt-plugin');
-// 5 minutes default, 0 to disable
-const TIMEOUT = process.env.PROC_TIMEOUT || '300000';
+
+// Disabled by default, to set run the CLI as `PROC_TIMEOUT=100000 snyk ...`
+const TIMEOUT = process.env.PROC_TIMEOUT || '0';
 const PROC_TIMEOUT = parseInt(TIMEOUT, 10);
 
 export const execute = (


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
SBT projects may take much longer than 5 minutes to generate dependency tree. removing timeout by default. 