### PR TITLE
fix: enable system tests on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,33 +1,28 @@
 build: off
+os: Windows Server 2012
 
 init:
   - git config --global core.autocrlf input
 
 install:
-  - java -version
-  - SET JAVA_HOME=C:\jdk8
-  - SET PATH=C:\jdk8\bin;%PATH%
-
-  - ps: |
-      Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\sbt" )) {
-        (new-object System.Net.WebClient).DownloadFile(
-          'https://piccolo.link/sbt-0.13.18.zip',
-          'C:\sbt-bin.zip'
-        )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-bin.zip", "C:\sbt")
-      }
-  - SET PATH=C:\sbt\sbt\bin;%PATH%
-  - SET SBT_OPTS=-Xmx4g -Dfile.encoding=UTF8
+  - cmd: choco install zulu8 -ia "INSTALLDIR=""C:\zulu"""
+  - cmd: SET JAVA_HOME="C:\zulu"
+  - cmd: choco install sbt -ia "INSTALLDIR=""C:\sbt"""
+  - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET SBT_OPTS=-Xms4g -Xmx4g
+  - cmd: SET COURSIER_VERBOSITY=-1
+  - cmd: SET JAVA_OPTS=-Xms4g -Xmx4g
   - ps: Install-Product node $env:nodejs_version
+  - java -version
   - node --version
   - npm --version
   - npm install
 
 cache:
-  - '%USERPROFILE%\.ivy2\cache'
+  - '%USERPROFILE%\.ivy2'
   - '%USERPROFILE%\.sbt'
   - node_modules -> package.json
+  - C:\Users\appveyor\.m2
 
 
 branches:
@@ -44,5 +39,4 @@ environment:
 
 test_script:
   - npm test
-  # TODO: fix setu and re-enable
-  # - npm run test-system
+  - npm run test-system-windows

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -97,7 +97,7 @@ function searchWithFs( filename ) {
 
 export function buildArgs(sbtArgs, isCoursierProject) {
   // force plain output so we don't have to parse colour codes
-  let args = ['-Dsbt.log.noformat=true'];
+  let args = ['\"-Dsbt.log.noformat=true\"'];
   if (sbtArgs) {
     args = args.concat(sbtArgs);
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prepare": "npm run build",
     "test": "npm run lint && npm run build && npm run test-functional",
     "test-functional": "tap -Rspec ./test/functional/*.test.[tj]s",
-    "test-system": "tap -Rspec --timeout=600 ./test/system/*.test.[tj]s"
+    "test-system": "tap -Rspec --timeout=600 ./test/system/*.test.[tj]s",
+    "test-system-windows": "tap -Rspec --timeout=600 ./test/system-windows/*.test.[tj]s"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",

--- a/test/fixtures/testproj-1.2.8/project/site.sbt
+++ b/test/fixtures/testproj-1.2.8/project/site.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+ThisBuild / scalaVersion := "2.12.8"

--- a/test/functional/sbt-plugin.test.ts
+++ b/test/functional/sbt-plugin.test.ts
@@ -7,7 +7,7 @@ test('check build args with array not coursier', (t) => {
     '-Pjaxen',
   ], false);
   t.deepEqual(result, [
-    '-Dsbt.log.noformat=true',
+    '"-Dsbt.log.noformat=true\"',
     '-Paxis',
     '-Pjaxen',
     'dependencyTree',
@@ -18,7 +18,7 @@ test('check build args with array not coursier', (t) => {
 test('check build args with string not coursie', (t) => {
   const result = plugin.buildArgs('-Paxis -Pjaxen', false);
   t.deepEqual(result, [
-    '-Dsbt.log.noformat=true',
+    '"-Dsbt.log.noformat=true\"',
     '-Paxis -Pjaxen',
     'dependencyTree',
   ]);
@@ -31,7 +31,7 @@ test('check build args with array for coursier', (t) => {
     '-Pjaxen',
   ], true);
   t.deepEqual(result, [
-    '-Dsbt.log.noformat=true',
+    '"-Dsbt.log.noformat=true\"',
     '-Paxis',
     '-Pjaxen',
     'coursierDependencyTree',
@@ -42,7 +42,7 @@ test('check build args with array for coursier', (t) => {
 test('check build args with string for coursier', (t) => {
   const result = plugin.buildArgs('-Paxis -Pjaxen', true);
   t.deepEqual(result, [
-    '-Dsbt.log.noformat=true',
+    '"-Dsbt.log.noformat=true\"',
     '-Paxis -Pjaxen',
     'coursierDependencyTree',
   ]);

--- a/test/system-windows/plugin.test.ts
+++ b/test/system-windows/plugin.test.ts
@@ -1,0 +1,118 @@
+import * as path from 'path';
+import * as test from 'tap-only';
+// import * as sinon from 'sinon';
+import * as plugin from '../../lib';
+// import * as subProcess from '../../lib/sub-process';
+
+test('run inspect() 0.13', async (t) => {
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+    'testproj-0.13/build.sbt', { debug: true});
+  // top level package is not added as a dep on windows
+  t.equal(result.package.version, '1.4');
+  t.match(result.package.name, 'axis:axis');
+  t.deepEqual(result.package
+    .dependencies['axis:axis-jaxrpc']
+    .dependencies['org.apache.axis:axis-jaxrpc'].version,
+  '1.4',
+  'correct version found');
+});
+
+test('run inspect() on 1.2.8', async (t) => {
+  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+  'testproj-1.2.8/build.sbt', {});
+  // top level package is not added as a dep on windows
+  t.equal(result.package.version, '1.4');
+  t.match(result.package.name, 'axis:axis');
+  t.deepEqual(result.package
+    .dependencies['axis:axis-jaxrpc']
+    .dependencies['org.apache.axis:axis-jaxrpc'].version,
+  '1.4',
+  'correct version found');
+});
+
+// TODO: fix coursier on windows
+// test('run inspect() with coursier on 0.17', async (t) => {
+//   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+//     'testproj-coursier-0.13/build.sbt', {});
+//   // top level package is not added as a dep on windows
+//   t.equal(result.package.version, '1.4');
+//   t.match(result.package.name, 'axis:axis');
+//   t.deepEqual(result.package
+//     .dependencies['axis:axis-jaxrpc']
+//     .dependencies['org.apache.axis:axis-jaxrpc'].version,
+//   '1.4',
+//   'correct version found');
+// });
+
+// test('run inspect() with coursier on 1.2.8', async (t) => {
+//   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+//     'testproj-coursier-1.2.8/build.sbt', {});
+//   // top level package is not added as a dep on windows
+//   t.equal(result.package.version, '1.4');
+//   t.match(result.package.name, 'axis:axis');
+//   t.deepEqual(result.package
+//     .dependencies['axis:axis-jaxrpc']
+//     .dependencies['org.apache.axis:axis-jaxrpc'].version,
+//   '1.4',
+//   'correct version found');
+// });
+
+test('run inspect() with no sbt plugin on 0.13', async (t) => {
+  try {
+    await plugin.inspect(path.join(
+    __dirname, '..', 'fixtures', 'testproj-noplugin-0.13'),
+  'build.sbt', {});
+    t.fail('should not be reached');
+  } catch (error) {
+    t.match(error.message, 'the `sbt-dependency-graph` plugin');
+    t.pass('Error thrown correctly');
+  }
+});
+
+test('run inspect() with commented out coursier on 0.13', async (t) => {
+  const result: any  = await plugin.inspect(path.join(
+    __dirname, '..', 'fixtures', 'testproj-faux-coursier-0.13'),
+  'build.sbt', {});
+  // top level package is not added as a dep on windows
+  t.equal(result.package.version, '1.4');
+  t.match(result.package.name, 'axis:axis');
+  t.deepEqual(result.package
+    .dependencies['axis:axis-jaxrpc']
+    .dependencies['org.apache.axis:axis-jaxrpc'].version,
+  '1.4',
+  'correct version found');
+});
+
+// TODO: fix, seems to timeout?
+// test('run inspect() on bad project requiring user input', async (t) => {
+//   try {
+//     await plugin.inspect(path.join(__dirname, '..', 'fixtures',
+//     'bad-project'), 'build.sbt', {});
+//     t.fail('Expected to fail');
+//   } catch (error) {
+//     t.match(error.message, 'code: 1');
+//     t.match(error.message, '(q)uit');
+//     t.pass('Error thrown correctly');
+//   }
+// });
+
+// TODO: fix, seems to timeout?
+// test('run inspect() with failing `sbt` execution', async (t) => {
+//   stubSubProcessExec(t);
+//   try {
+//     await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+//     'testproj-0.13/build.sbt', {});
+//     t.fail('should not be reached');
+//   } catch (error) {
+//     t.match(error.message, 'abort');
+//     t.pass('Error thrown correctly');
+//   }
+// });
+
+// function stubSubProcessExec(t) {
+//   const executeStub = sinon.stub(subProcess, 'execute')
+//     .callsFake(() => {
+//       return Promise.reject(new Error('abort'));
+//     });
+//   t.teardown(executeStub.restore);
+// }

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -4,10 +4,13 @@ import * as sinon from 'sinon';
 import * as plugin from '../../lib';
 import * as subProcess from '../../lib/sub-process';
 
-test('run inspect()', async (t) => {
+test('run inspect() 0.13', async (t) => {
   const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-0.13/build.sbt', { debug: true});
-  t.equal(result.package
+  t.equal(result.package.version, '0.1.0-SNAPSHOT');
+  t.match(result.package.name, 'hello');
+
+  t.deepEqual(result.package
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
@@ -18,7 +21,9 @@ test('run inspect()', async (t) => {
 test('run inspect() on 1.2.8', async (t) => {
   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
   'testproj-1.2.8/build.sbt', {});
-  t.equal(result.package
+  t.equal(result.package.version, '0.1.0-SNAPSHOT');
+  t.match(result.package.name, 'hello');
+  t.deepEqual(result.package
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
@@ -29,7 +34,12 @@ test('run inspect() on 1.2.8', async (t) => {
 test('run inspect() with coursier on 0.17', async (t) => {
   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-coursier-0.13/build.sbt', {});
-  t.equal(result.package
+  // TODO: fix to get the project name from build.sbt
+  // for coursier project
+  // t.equal(result.package.version, '0.1.0-SNAPSHOT')
+  // t.match(result.package.name, 'hello');
+  t.ok(result.package.dependencies['axis:axis']);
+  t.deepEqual(result.package
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
@@ -40,7 +50,12 @@ test('run inspect() with coursier on 0.17', async (t) => {
 test('run inspect() with coursier on 1.2.8', async (t) => {
   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-coursier-1.2.8/build.sbt', {});
-  t.equal(result.package
+  // TODO: fix to get the project name from build.sbt
+  // for coursier project
+  // t.equal(result.package.version, '0.1.0-SNAPSHOT');
+  // t.match(result.package.name, 'hello');
+  t.ok(result.package.dependencies['axis:axis']);
+  t.deepEqual(result.package
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
@@ -64,7 +79,11 @@ test('run inspect() with commented out coursier on 0.13', async (t) => {
   const result: any  = await plugin.inspect(path.join(
     __dirname, '..', 'fixtures', 'testproj-faux-coursier-0.13'),
   'build.sbt', {});
-  t.equal(result.package
+  // TODO: fix to get the project name from build.sbt
+  // t.equal(result.package.version, '0.1.0-SNAPSHOT');
+  t.match(result.package.name, 'hello');
+  t.ok(result.package.dependencies['axis:axis']);
+  t.deepEqual(result.package
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Partially enable system tests on appveyor
Windows version of the tree doesn't have the top level package as a first dep, so adding special test file for this.
Coursier support is not working and needs further debugging in another PR