### PR TITLE
Feat/use dep graph instead of trees

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,8 @@
+import {DepGraph} from '@snyk/dep-graph';
+
 export interface PluginResult {
   plugin: PluginMetadata;
-  package: DepTree;
+  package: DepTree|DepGraph[];
 }
 
 export interface DepDict {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typescript": "3.4.5"
   },
   "dependencies": {
+    "@snyk/dep-graph": "1.9.0",
     "child_process": "1.0.2",
     "fs": "0.0.1-security",
     "path": "0.12.7",

--- a/test/functional/parse-sbt.test.ts
+++ b/test/functional/parse-sbt.test.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as test from 'tap-only';
 import * as parser from '../../lib/parse-sbt';
+import * as DepGraphLib from '@snyk/dep-graph';
+import * as types from '../../lib/types';
 
 function flatten(dependencies) {
   const acc = new Set();
@@ -98,7 +100,8 @@ test('parse `sbt dependencies` output: plugin 1.2.8', async (t) => {
       __dirname, '..', 'fixtures',
       'sbt-plugin-1.2.8-output.txt'),
     'utf8');
-  const depTree = parser.parseSbtPluginResults(sbtOutput);
+  const depGraph = parser.parseSbtPluginResults(sbtOutput)[0];
+  const depTree = await DepGraphLib.legacy.graphToDepTree(depGraph, 'sbt');
 
   t.equal(depTree.name, 'com.example:hello_2.12');
   t.equal(depTree.version, '0.1.0-SNAPSHOT');
@@ -121,7 +124,8 @@ test('parse `sbt dependencies` output: plugin 0.13', async (t) => {
     __dirname, '..', 'fixtures',
     'sbt-plugin-0.13-output.txt'),
     'utf8');
-  const depTree = parser.parseSbtPluginResults(sbtOutput);
+  const depGraph = parser.parseSbtPluginResults(sbtOutput)[0];
+  const depTree = await DepGraphLib.legacy.graphToDepTree(depGraph, 'sbt');
 
   t.equal(depTree.name, 'com.example:hello_2.12');
   t.equal(depTree.version, '0.1.0-SNAPSHOT');


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Moves from DepTrees to DepGraphs when using modules graph output from SBT.

#### Where should the reviewer start?
https://www.npmjs.com/package/@snyk/dep-graph

#### How should this be manually tested?
Automated tests should be enough, but this version can be linked to local copy of snyk-cli and run against sbt project with `--sbt-graph` flag.

#### Any background context you want to provide?
New sbt plugin was created in order to deal with big projects, but converting the data back to depTree would cause the problem in a different part. As sbt-plugin already returns a graph of deps, using DepGraph is the most straight forward solution.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-741

#### Screenshots


#### Additional questions
