### PR TITLE
fix: rename new plugin name for analytics

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -136,7 +136,7 @@ async function pluginInspect(root: string, targetFile: string, options: any): Pr
 
     return {
       plugin: {
-        name: 'bundled:sbt',
+        name: 'snyk:sbt',
         runtime: 'unknown',
       },
       package: parser.parseSbtPluginResults(stdout),

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -7,6 +7,8 @@ import * as subProcess from '../../lib/sub-process';
 test('run inspect() 0.13', async (t) => {
   const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-0.13/build.sbt', { debug: true});
+  t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
+
   t.equal(result.package.version, '0.1.0-SNAPSHOT');
   t.match(result.package.name, 'hello');
 
@@ -21,6 +23,8 @@ test('run inspect() 0.13', async (t) => {
 test('run inspect() on 1.2.8', async (t) => {
   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
   'testproj-1.2.8/build.sbt', {});
+  t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
+
   t.equal(result.package.version, '0.1.0-SNAPSHOT');
   t.match(result.package.name, 'hello');
   t.deepEqual(result.package
@@ -38,6 +42,8 @@ test('run inspect() with coursier on 0.17', async (t) => {
   // for coursier project
   // t.equal(result.package.version, '0.1.0-SNAPSHOT')
   // t.match(result.package.name, 'hello');
+  t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
+
   t.ok(result.package.dependencies['axis:axis']);
   t.deepEqual(result.package
     .dependencies['axis:axis']
@@ -54,6 +60,7 @@ test('run inspect() with coursier on 1.2.8', async (t) => {
   // for coursier project
   // t.equal(result.package.version, '0.1.0-SNAPSHOT');
   // t.match(result.package.name, 'hello');
+  t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
   t.ok(result.package.dependencies['axis:axis']);
   t.deepEqual(result.package
     .dependencies['axis:axis']
@@ -79,6 +86,7 @@ test('run inspect() with commented out coursier on 0.13', async (t) => {
   const result: any  = await plugin.inspect(path.join(
     __dirname, '..', 'fixtures', 'testproj-faux-coursier-0.13'),
   'build.sbt', {});
+  t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
   // TODO: fix to get the project name from build.sbt
   // t.equal(result.package.version, '0.1.0-SNAPSHOT');
   t.match(result.package.name, 'hello');
@@ -138,6 +146,7 @@ function stubSubProcessExec(t) {
 test('run inspect() on 0.13 with custom-plugin', async (t) => {
   const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-0.13/build.sbt', {'sbt-graph': true});
+  t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
   t.equal(result.package
       .dependencies['axis:axis']
       .dependencies['axis:axis-jaxrpc']
@@ -149,6 +158,7 @@ test('run inspect() on 0.13 with custom-plugin', async (t) => {
 test('run inspect() on 1.2.8 with custom-plugin', async (t) => {
   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-1.2.8/build.sbt', {'sbt-graph': true});
+  t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
   t.equal(result.package
       .dependencies['axis:axis']
       .dependencies['axis:axis-jaxrpc']


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Change the name of the handling plugin so it can be differentiated in the CLI analytics.