### PR TITLE
fix: add scala folder to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/snyk/snyk-sbt-plugin"
   },
   "files": [
-    "dist"
+    "dist",
+    "scala"
   ],
   "directories": {
     "test": "test"


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Add `scala` folder to `files` key in `package.json` so it will pack it correctly
