### PR TITLE
Denylist PlayWeb configuration names with undefined config keys. Fixes #57

### DIFF
--- a/scala/SnykSbtPlugin-0.1x.scala
+++ b/scala/SnykSbtPlugin-0.1x.scala
@@ -10,7 +10,7 @@ import org.json4s._
 
 object SnykSbtPlugin extends AutoPlugin {
   val ConfigBlacklist: Set[String] =
-    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux")
+    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux", "web-assets", "web-plugin", "web-assets-test")
 
   case class SnykModuleInfo(version: String, configurations: Set[String])
 

--- a/scala/SnykSbtPlugin-1.2x.scala
+++ b/scala/SnykSbtPlugin-1.2x.scala
@@ -8,7 +8,7 @@ import sjsonnew.support.scalajson.unsafe.PrettyPrinter
 
 object SnykSbtPlugin extends AutoPlugin {
   val ConfigBlacklist: Set[String] =
-    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux")
+    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux", "web-assets", "web-plugin", "web-assets-test")
 
   case class SnykModuleInfo(version: String, configurations: Set[String])
   case class SnykProjectData(

--- a/test/fixtures/testproj-play-scala-seed-1.2.8/.gitignore
+++ b/test/fixtures/testproj-play-scala-seed-1.2.8/.gitignore
@@ -1,0 +1,8 @@
+logs
+target
+/.idea
+/.idea_modules
+/.classpath
+/.project
+/.settings
+/RUNNING_PID

--- a/test/fixtures/testproj-play-scala-seed-1.2.8/build.sbt
+++ b/test/fixtures/testproj-play-scala-seed-1.2.8/build.sbt
@@ -1,0 +1,17 @@
+name := """testproj-play-scala-seed-1.2.8"""
+organization := "com.example"
+
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := "2.13.0"
+
+libraryDependencies += guice
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
+
+// Adds additional packages into Twirl
+//TwirlKeys.templateImports += "com.example.controllers._"
+
+// Adds additional packages into conf/routes
+// play.sbt.routes.RoutesKeys.routesImport += "com.example.binders._"

--- a/test/fixtures/testproj-play-scala-seed-1.2.8/project/build.properties
+++ b/test/fixtures/testproj-play-scala-seed-1.2.8/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/test/fixtures/testproj-play-scala-seed-1.2.8/project/plugins.sbt
+++ b/test/fixtures/testproj-play-scala-seed-1.2.8/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -192,3 +192,17 @@ test('run inspect() on 1.2.8 with custom-plugin', async (t) => {
     '1.4',
     'correct version found');
 });
+
+test('run inspect() on play-scala-seed 1.2.8 with custom-plugin', async (t) => {
+  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+    'testproj-play-scala-seed-1.2.8/build.sbt', {'sbt-graph': true});
+  t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
+
+  t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
+  t.equal(result.package
+      .dependencies['com.typesafe.play:play-guice_2.13']
+      .dependencies['com.typesafe.play:play_2.13']
+      .dependencies['com.fasterxml.jackson.datatype:jackson-datatype-jsr310'].version,
+    '2.9.8',
+    'correct version found');
+});


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Adds three new configuration keys, `web-assets`, `web-plugin` and `web-assets-test` to the denylist of config keys that are used in the Snyk sbt plugin (currently opt-in with `--sbt-graph`) to enable the plugin to work out of the box with Play Framework projects that use the standard Play plugin.

#### How should this be manually tested?

As per the instructions in #57:

* Create a new Play scala seed project: `sbt new playframework/play-scala-seed.g8`
* Accept the defaults; `cd play-scala-seed`
* Copy the Snyk sbt plugin from this PR to `project/SnykSbtPlugin.scala`
* Install the sbt-dependency-graph plugin locally on the project: `echo 'addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")' | tee --append project/plugins.sbt`
* Run `sbt snykRenderTree`

#### What are the relevant tickets?

Fixes #57 