### PR TITLE
docs: clarify usage of plugin is not to be used as standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Snyk helps you find, fix and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your CI (Build) system.
 
+| :information_source: This repository is only a plugin to be used with the Snyk CLI tool. To use this plugin to test and fix vulnerabilities in your project, install the Snyk CLI tool first. Head over to [snyk.io](https://github.com/snyk/snyk) to get started. |
+| --- |
+
+
 ## Snyk SBT CLI Plugin
 
 This plugin provides dependency metadata for SBT projects that use `sbt` and have a `build.sbt` file.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ This plugin provides dependency metadata for SBT projects that use `sbt` and hav
 
 ## Supported Java & Sbt versions
 
-| Java Sbt|0.13.* |1.1.*|1.2.* |
-|---|---|---|---|
-| 8  |  ✅ |  ❓ |  ✅ |
-| 9  | ✅  | ❓ |  ✅ |
-| 10  |  ✅ | ❓ |  ✅ |
-| 11  |  ✅ |  ❓ |  ✅ |
-| 12  |  ✅ |  ❓ |  ✅ |
-| 13  |  🚫 |  ❓ |  🚫 |
+| Java Sbt|0.13.* |1.1.*|1.2.* |1.3.2 |1.3.3|
+|---|---|---|---|---|---|
+| 8   |  ✅ | ❓ |  ✅ | ✅ | 🚫 |
+| 9   |  ✅ | ❓ |  ✅ | ✅ | 🚫 |
+| 10  |  ✅ | ❓ |  ✅ | ✅ | 🚫 |
+| 11  |  ✅ | ❓ |  ✅ | ✅ | 🚫 |
+| 12  |  ✅ | ❓ |  ✅ | ✅ | 🚫 |
+| 13  |  🚫 | ❓ |  🚫 | ✅ | 🚫 |
 
 `jdk13` is not currently supported (See this [comment](https://github.com/snyk/snyk-sbt-plugin/pull/61#issuecomment-521356342) for more details)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
 install:
   - cmd: choco install zulu8 -ia "INSTALLDIR=""C:\zulu"""
   - cmd: SET JAVA_HOME="C:\zulu"
-  - cmd: choco install sbt -ia "INSTALLDIR=""C:\sbt"""
+  - cmd: choco install sbt --version=1.3.2 -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET SBT_OPTS=-Xms4g -Xmx4g
   - cmd: SET COURSIER_VERBOSITY=-1


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds clarification that the purpose of the plugin is not to be used as a standalone app, but instead use the Snyk CLI tool instead

#### What are the relevant tickets?
#64 