### PR TITLE
feat: scan with --sbt-graph by default

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -20,15 +20,13 @@ export async function inspect(root, targetFile, options): Promise<types.PluginRe
     options = {dev: false};
   }
 
-  if (options['sbt-graph']) {
-    const res = await pluginInspect(root, targetFile, options);
-    if (res) {
-      res.package.packageFormatVersion = packageFormatVersion;
+  const res = await pluginInspect(root, targetFile, options);
+  if (res) {
+    res.package.packageFormatVersion = packageFormatVersion;
 
-      return res;
-    } else {
-      debug('Falling back to legacy inspect');
-    }
+    return res;
+  } else {
+    debug('Falling back to legacy inspect');
   }
 
   const result = await legacyInspect(root, targetFile, options);

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -121,7 +121,7 @@ test('run inspect() on bad project requiring user input', async (t) => {
 test('run inspect() on bad-project cascade through all parsing options', async (t) => {
   try {
     await plugin.inspect(path.join(__dirname, '..', 'fixtures',
-      'bad-project'), 'build.sbt', {'sbt-graph': true});
+      'bad-project'), 'build.sbt', {});
     t.fail('Expected to fail');
   } catch (error) {
     t.match(error.message, 'code: 1');
@@ -152,7 +152,7 @@ function stubSubProcessExec(t) {
 
 test('run inspect() on 0.13 with custom-plugin', async (t) => {
   const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-    'testproj-0.13/build.sbt', {'sbt-graph': true});
+    'testproj-0.13/build.sbt', {});
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
@@ -167,7 +167,7 @@ test('run inspect() on 0.13 with custom-plugin', async (t) => {
 // test for new plugin solving issue where native configurations were failing to build for snyk
 test('run inspect() on 0.13 with custom-plugin native-packages', async (t) => {
   const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-    'testproj-0.13-native-packager/build.sbt', {'sbt-graph': true});
+    'testproj-0.13-native-packager/build.sbt', {});
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
@@ -181,7 +181,7 @@ test('run inspect() on 0.13 with custom-plugin native-packages', async (t) => {
 
 test('run inspect() on 1.2.8 with custom-plugin', async (t) => {
   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-    'testproj-1.2.8/build.sbt', {'sbt-graph': true});
+    'testproj-1.2.8/build.sbt', {});
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
@@ -195,7 +195,7 @@ test('run inspect() on 1.2.8 with custom-plugin', async (t) => {
 
 test('run inspect() on play-scala-seed 1.2.8 with custom-plugin', async (t) => {
   const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-    'testproj-play-scala-seed-1.2.8/build.sbt', {'sbt-graph': true});
+    'testproj-play-scala-seed-1.2.8/build.sbt', {});
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Make scanning via `--sbt-graph` the default.

#### What are the relevant tickets?
#67 

#### Testing

Ran first with latest `snyk` with no parameters
```
snyk test snyk-sbt-plugin/test/fixtures/testproj-0.13  > old_format.json
```

Second run with latest `snyk` with `--sbt-graph` parameter
```
snyk test snyk-sbt-plugin/test/fixtures/testproj-0.13 --sbt-graph --json > old_format_with_sbt-graph.json
```

Third test with locally modified `snyk-sbt-plugin`
```
node dist/cli/index test snyk-sbt-plugin/test/fixtures/testproj-0.13 --json > new_format.json
```

Performed a `diff` between the 3 files and no diff are showing