### PR TITLE
chore(ci): use Node 14 for release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ workflows:
     - release:
         name: Release
         context: nodejs-app-release
-        node_version: "8"
+        node_version: "14"
         filters:
           branches:
             only:


### PR DESCRIPTION
Release step is currently failing on old Node.js version