### PR TITLE
fix: add fallback project path & report sbt version in analytics

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,13 @@ export interface DepTree {
 export interface PluginMetadata {
   name: string;
   runtime: string;
+  meta?: {
+    versionBuildInfo?: {
+      metaBuildVersion?: {
+        sbtVersion?: string,
+      },
+    },
+  };
 }
 
 export interface SbtModulesGraph {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

We've noticed the sbt plugin failing with what looks like a wrong path to the `project/` folder. This patch set adds a fallback to building it.

It also reports the sbt version used to build the project.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
