### PR TITLE
feat: search sbt dep graph plugin in the new naming

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,2 +1,3 @@
 export const sbtCoursierPluginName = 'sbt-coursier';
 export const sbtDependencyGraphPluginName = 'sbt-dependency-graph';
+export const sbtDependencyGraphPluginNameNew = 'addDependencyTreePlugin';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,7 @@ import * as debugModule from 'debug';
 // To enable debugging output, run the CLI as `DEBUG=snyk-sbt-plugin snyk ...`
 const debug = debugModule('snyk-sbt-plugin');
 
-import { sbtCoursierPluginName, sbtDependencyGraphPluginName } from './constants';
+import { sbtCoursierPluginName, sbtDependencyGraphPluginName, sbtDependencyGraphPluginNameNew } from './constants';
 import * as subProcess from './sub-process';
 import * as parser from './parse-sbt';
 import * as types from './types';
@@ -41,7 +41,8 @@ export async function inspect(
     root,
     targetFile,
     sbtDependencyGraphPluginName,
-  );
+  ) || await isPluginInstalled(root,
+    targetFile, sbtDependencyGraphPluginNameNew);
   Object.assign(options, { isCoursierPresent });
   // in order to apply the pluginInspect, coursier should *not* be present and sbt-dependency-graph should be present
   if (!isCoursierPresent && isSbtDependencyGraphPresent) {
@@ -54,9 +55,9 @@ export async function inspect(
     } else {
       debug(
         'coursier present = ' +
-          isCoursierPresent +
-          ', sbt-dependency-graph present = ' +
-          isSbtDependencyGraphPresent,
+        isCoursierPresent +
+        ', sbt-dependency-graph present = ' +
+        isSbtDependencyGraphPresent,
       );
       debug('Falling back to legacy inspect');
       // tslint:disable-next-line:no-console
@@ -206,7 +207,7 @@ async function pluginInspect(
   } catch (error) {
     debug(
       'Failed to produce dependency tree with custom snyk plugin due to error: ' +
-        error.message,
+      error.message,
     );
     return null;
   } finally {

--- a/test/fixtures/homedir-1.0-sbt-1.4+/.sbt/1.0/plugins/plugins.sbt
+++ b/test/fixtures/homedir-1.0-sbt-1.4+/.sbt/1.0/plugins/plugins.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin

--- a/test/functional/plugin-search.spec.ts
+++ b/test/functional/plugin-search.spec.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as version from '../../lib/version';
 import { isPluginInstalled } from '../../lib/plugin-search';
-import { sbtDependencyGraphPluginName} from '../../lib/constants';
+import { sbtDependencyGraphPluginName, sbtDependencyGraphPluginNameNew } from '../../lib/constants';
 
 describe('plugin-search test', () => {
   describe('isPluginInstalled locally', () => {
@@ -63,7 +63,7 @@ describe('plugin-search test', () => {
     });
   });
 
-  describe('isPluginInstalled globally into 1.0', () => {
+  describe('isPluginInstalled globally into 1.0, using sbt-dependency-graph old naming convention', () => {
     beforeEach(() => {
       const homedir = path.join(__dirname, '..', 'fixtures', 'homedir-1.0');
       jest.spyOn(os, 'homedir').mockReturnValue(homedir);
@@ -74,7 +74,39 @@ describe('plugin-search test', () => {
       it('returns true if ~/.sbt/1.0/plugins directory has sbt file with given plugin name', async () => {
         const root = path.join(__dirname, '..', 'fixtures');
         const targetFile = path.join('simple-app', 'build.sbt');
-        const received = await isPluginInstalled(root, targetFile, sbtDependencyGraphPluginName)
+        const received = await isPluginInstalled(root, targetFile, sbtDependencyGraphPluginName) ||
+          await isPluginInstalled(
+            root,
+            targetFile,
+            sbtDependencyGraphPluginNameNew
+          );
+        expect(received).toBe(true);
+      });
+      it('returns false if ~/.sbt/1.0/plugins directory has sbt file without plugin name', async () => {
+        const root = path.join(__dirname, '..', 'fixtures');
+        const targetFile = path.join('simple-app', 'build.sbt');
+        const received = await isPluginInstalled(root, targetFile, 'will.not.find');
+        expect(received).toBe(false);
+      });
+    });
+  });
+  describe('isPluginInstalled globally into 1.0, using addDependencyTreePlugin introduced for sbt versions 1.4+', () => {
+    beforeEach(() => {
+      const homedir = path.join(__dirname, '..', 'fixtures', 'homedir-1.0-sbt-1.4+');
+      jest.spyOn(os, 'homedir').mockReturnValue(homedir);
+      jest.spyOn(version, 'getSbtVersion').mockResolvedValue('1.0.0');
+    });
+    afterEach(() => jest.resetAllMocks());
+    describe('in users home directory', () => {
+      it('returns true if ~/.sbt/1.0/plugins directory has sbt file with given plugin name', async () => {
+        const root = path.join(__dirname, '..', 'fixtures');
+        const targetFile = path.join('simple-app', 'build.sbt');
+        const received = await isPluginInstalled(root, targetFile, sbtDependencyGraphPluginName) ||
+          await isPluginInstalled(
+            root,
+            targetFile,
+            sbtDependencyGraphPluginNameNew
+          );
         expect(received).toBe(true);
       });
       it('returns false if ~/.sbt/1.0/plugins directory has sbt file without plugin name', async () => {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When looking for the needed plugin for our new inspect() flow, we were not globing for the new method of including such plugin for sbt versions 1.4+ which says to include addDependencyTreePlugin on your plugins.sbt.

#### Any background context you want to provide?
See https://github.com/sbt/sbt-dependency-graph#usage-instructions
