### PR TITLE
feat: warn users when using new sbt-dependency-graph annotation

### DIFF
--- a/test/fixtures/simple-app-sbt-1.4.0/build.sbt
+++ b/test/fixtures/simple-app-sbt-1.4.0/build.sbt
@@ -1,0 +1,40 @@
+import Dependencies._
+
+ThisBuild / scalaVersion     := "2.12.8"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "simple-app",
+    libraryDependencies += scalaTest % Test
+  )
+
+// Uncomment the following for publishing to Sonatype.
+// See https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html for more detail.
+
+// ThisBuild / description := "Some descripiton about your project."
+// ThisBuild / licenses    := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+// ThisBuild / homepage    := Some(url("https://github.com/example/project"))
+// ThisBuild / scmInfo := Some(
+//   ScmInfo(
+//     url("https://github.com/your-account/your-project"),
+//     "scm:git@github.com:your-account/your-project.git"
+//   )
+// )
+// ThisBuild / developers := List(
+//   Developer(
+//     id    = "Your identifier",
+//     name  = "Your Name",
+//     email = "your@email",
+//     url   = url("http://your.url")
+//   )
+// )
+// ThisBuild / pomIncludeRepository := { _ => false }
+// ThisBuild / publishTo := {
+//   val nexus = "https://oss.sonatype.org/"
+//   if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+//   else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+// }
+// ThisBuild / publishMavenStyle := true

--- a/test/fixtures/simple-app-sbt-1.4.0/project/Dependencies.scala
+++ b/test/fixtures/simple-app-sbt-1.4.0/project/Dependencies.scala
@@ -1,0 +1,5 @@
+import sbt._
+
+object Dependencies {
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+}

--- a/test/fixtures/simple-app-sbt-1.4.0/project/build.properties
+++ b/test/fixtures/simple-app-sbt-1.4.0/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.0

--- a/test/fixtures/simple-app-sbt-1.4.0/src/main/scala/example/Hello.scala
+++ b/test/fixtures/simple-app-sbt-1.4.0/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/test/fixtures/simple-app-sbt-1.4.0/src/test/scala/example/HelloSpec.scala
+++ b/test/fixtures/simple-app-sbt-1.4.0/src/test/scala/example/HelloSpec.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest._
+
+class HelloSpec extends FlatSpec with Matchers {
+  "The Hello object" should "say hello" in {
+    Hello.greeting shouldEqual "hello"
+  }
+}

--- a/test/fixtures/testproj-1.4.0/build.sbt
+++ b/test/fixtures/testproj-1.4.0/build.sbt
@@ -1,0 +1,10 @@
+lazy val root = (project in file(".")).
+  settings(
+    inThisBuild(List(
+      organization := "com.example",
+      scalaVersion := "2.12.1",
+      version      := "0.1.0-SNAPSHOT"
+    )),
+    name := "Hello",
+    libraryDependencies += "axis" % "axis" % "1.4"
+  )

--- a/test/fixtures/testproj-1.4.0/project/build.properties
+++ b/test/fixtures/testproj-1.4.0/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.4.0

--- a/test/fixtures/testproj-1.4.0/project/site.sbt
+++ b/test/fixtures/testproj-1.4.0/project/site.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin

--- a/test/fixtures/testproj-1.4.0/src/main/scala/example/Hello.scala
+++ b/test/fixtures/testproj-1.4.0/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/test/functional/plugin-search.spec.ts
+++ b/test/functional/plugin-search.spec.ts
@@ -90,6 +90,7 @@ describe('plugin-search test', () => {
       });
     });
   });
+
   describe('isPluginInstalled globally into 1.0, using addDependencyTreePlugin introduced for sbt versions 1.4+', () => {
     beforeEach(() => {
       const homedir = path.join(__dirname, '..', 'fixtures', 'homedir-1.0-sbt-1.4+');
@@ -100,7 +101,7 @@ describe('plugin-search test', () => {
     describe('in users home directory', () => {
       it('returns true if ~/.sbt/1.0/plugins directory has sbt file with given plugin name', async () => {
         const root = path.join(__dirname, '..', 'fixtures');
-        const targetFile = path.join('simple-app', 'build.sbt');
+        const targetFile = path.join('simple-app-sbt-1.4.0', 'build.sbt');
         const received = await isPluginInstalled(root, targetFile, sbtDependencyGraphPluginName) ||
           await isPluginInstalled(
             root,

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -6,7 +6,7 @@ import * as subProcess from '../../lib/sub-process';
 
 test('run inspect() 0.13', async (t) => {
   const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-    'testproj-0.13/build.sbt', { debug: true});
+    'testproj-0.13/build.sbt', { debug: true });
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
@@ -17,13 +17,13 @@ test('run inspect() 0.13', async (t) => {
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
-  '1.4',
-  'correct version found');
+    '1.4',
+    'correct version found');
 });
 
 test('run inspect() on 1.2.8', async (t) => {
-  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-  'testproj-1.2.8/build.sbt', {});
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+    'testproj-1.2.8/build.sbt', {});
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
@@ -33,12 +33,25 @@ test('run inspect() on 1.2.8', async (t) => {
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
-  '1.4',
-  'correct version found');
+    '1.4',
+    'correct version found');
+});
+
+test('run legacy inspect() on sbt 1.4.0 with sbt-dependency-graph new naming- addDependencyTreePlugin', async (t) => {
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+    'testproj-1.4.0/build.sbt', {});
+  t.equal(result.plugin.name, 'bundled:sbt', 'falling back to legacy handler');
+  t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
+  t.equal(result.package.version, '0.1.0-SNAPSHOT');
+  t.match(result.package.name, 'hello');
+  t.deepEqual(result.package
+    .dependencies['axis:axis'].version,
+    '1.4',
+    'correct version found');
 });
 
 test('run inspect() with coursier on 0.17', async (t) => {
-  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-coursier-0.13/build.sbt', {});
   // TODO: fix to get the project name from build.sbt
   // for coursier project
@@ -52,12 +65,12 @@ test('run inspect() with coursier on 0.17', async (t) => {
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
-  '1.4',
-  'correct version found');
+    '1.4',
+    'correct version found');
 });
 
 test('run inspect() with coursier on 1.2.8', async (t) => {
-  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-coursier-1.2.8/build.sbt', {});
   // TODO: fix to get the project name from build.sbt
   // for coursier project
@@ -71,15 +84,15 @@ test('run inspect() with coursier on 1.2.8', async (t) => {
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
-  '1.4',
-  'correct version found');
+    '1.4',
+    'correct version found');
 });
 
 test('run inspect() with no sbt plugin on 0.13', async (t) => {
   try {
     await plugin.inspect(path.join(
-    __dirname, '..', 'fixtures', 'testproj-noplugin-0.13'),
-  'build.sbt', {});
+      __dirname, '..', 'fixtures', 'testproj-noplugin-0.13'),
+      'build.sbt', {});
     t.fail('should not be reached');
   } catch (error) {
     t.match(error.message, 'the `sbt-dependency-graph` plugin');
@@ -88,9 +101,9 @@ test('run inspect() with no sbt plugin on 0.13', async (t) => {
 });
 
 test('run inspect() with commented out coursier on 0.13', async (t) => {
-  const result: any  = await plugin.inspect(path.join(
+  const result: any = await plugin.inspect(path.join(
     __dirname, '..', 'fixtures', 'testproj-faux-coursier-0.13'),
-  'build.sbt', {});
+    'build.sbt', {});
   t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
   // TODO: fix to get the project name from build.sbt
   // t.equal(result.package.version, '0.1.0-SNAPSHOT');
@@ -102,14 +115,14 @@ test('run inspect() with commented out coursier on 0.13', async (t) => {
     .dependencies['axis:axis']
     .dependencies['axis:axis-jaxrpc']
     .dependencies['org.apache.axis:axis-jaxrpc'].version,
-  '1.4',
-  'correct version found');
+    '1.4',
+    'correct version found');
 });
 
 test('run inspect() on bad project requiring user input', async (t) => {
   try {
     await plugin.inspect(path.join(__dirname, '..', 'fixtures',
-    'bad-project'), 'build.sbt', {});
+      'bad-project'), 'build.sbt', {});
     t.fail('Expected to fail');
   } catch (error) {
     t.match(error.message, 'code: 1');
@@ -134,7 +147,7 @@ test('run inspect() with failing `sbt` execution', async (t) => {
   stubSubProcessExec(t);
   try {
     await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-    'testproj-0.13/build.sbt', {});
+      'testproj-0.13/build.sbt', {});
     t.fail('should not be reached');
   } catch (error) {
     t.match(error.message, 'abort');
@@ -157,9 +170,9 @@ test('run inspect() on 0.13 with custom-plugin', async (t) => {
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
   t.equal(result.package
-      .dependencies['axis:axis']
-      .dependencies['axis:axis-jaxrpc']
-      .dependencies['org.apache.axis:axis-jaxrpc'].version,
+    .dependencies['axis:axis']
+    .dependencies['axis:axis-jaxrpc']
+    .dependencies['org.apache.axis:axis-jaxrpc'].version,
     '1.4',
     'correct version found');
 });
@@ -172,43 +185,43 @@ test('run inspect() on 0.13 with custom-plugin native-packages', async (t) => {
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
   t.equal(result.package
-      .dependencies['org.apache.spark:spark-sql_2.12']
-      .dependencies['com.fasterxml.jackson.core:jackson-databind']
-      .dependencies['com.fasterxml.jackson.core:jackson-core'].version,
+    .dependencies['org.apache.spark:spark-sql_2.12']
+    .dependencies['com.fasterxml.jackson.core:jackson-databind']
+    .dependencies['com.fasterxml.jackson.core:jackson-core'].version,
     '2.7.9',
     'correct version found');
 });
 
 test('run inspect() on 1.2.8 with custom-plugin', async (t) => {
-  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-1.2.8/build.sbt', {});
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
   t.equal(result.package
-      .dependencies['axis:axis']
-      .dependencies['axis:axis-jaxrpc']
-      .dependencies['org.apache.axis:axis-jaxrpc'].version,
+    .dependencies['axis:axis']
+    .dependencies['axis:axis-jaxrpc']
+    .dependencies['org.apache.axis:axis-jaxrpc'].version,
     '1.4',
     'correct version found');
 });
 
 test('run inspect() on play-scala-seed 1.2.8 with custom-plugin', async (t) => {
-  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-play-scala-seed-1.2.8/build.sbt', {});
   t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
 
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
   t.equal(result.package
-      .dependencies['com.typesafe.play:play-guice_2.13']
-      .dependencies['com.typesafe.play:play_2.13']
-      .dependencies['com.fasterxml.jackson.datatype:jackson-datatype-jsr310'].version,
+    .dependencies['com.typesafe.play:play-guice_2.13']
+    .dependencies['com.typesafe.play:play_2.13']
+    .dependencies['com.fasterxml.jackson.datatype:jackson-datatype-jsr310'].version,
     '2.9.8',
     'correct version found');
 });
 
 test('run inspect() with coursier on 1.3.3', async (t) => {
-  const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
     'testproj-coursier-1.3.3/build.sbt', {});
 
   // TODO: fix to get the project name from build.sbt
@@ -220,29 +233,29 @@ test('run inspect() with coursier on 1.3.3', async (t) => {
   t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
   t.ok(result.package.dependencies['axis:axis']);
   t.deepEqual(result.package
-        .dependencies['axis:axis']
-        .dependencies['axis:axis-jaxrpc']
-        .dependencies['org.apache.axis:axis-jaxrpc'].version,
+    .dependencies['axis:axis']
+    .dependencies['axis:axis-jaxrpc']
+    .dependencies['org.apache.axis:axis-jaxrpc'].version,
     '1.4',
     'correct version found');
 });
 
 test('run inspect() with coursier on 1.3.5', async (t) => {
-    const result: any  = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
-        'testproj-coursier-1.3.5/build.sbt', {});
+  const result: any = await plugin.inspect(path.join(__dirname, '..', 'fixtures'),
+    'testproj-coursier-1.3.5/build.sbt', {});
 
-    // TODO: fix to get the project name from build.sbt
-    // for coursier project
-    // t.equal(result.package.version, '0.1.0-SNAPSHOT');
-    // t.match(result.package.name, 'hello');
-    t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
+  // TODO: fix to get the project name from build.sbt
+  // for coursier project
+  // t.equal(result.package.version, '0.1.0-SNAPSHOT');
+  // t.match(result.package.name, 'hello');
+  t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
 
-    t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
-    t.ok(result.package.dependencies['axis:axis']);
-    t.deepEqual(result.package
-            .dependencies['axis:axis']
-            .dependencies['axis:axis-jaxrpc']
-            .dependencies['org.apache.axis:axis-jaxrpc'].version,
-        '1.4',
-        'correct version found');
+  t.equal(result.package.packageFormatVersion, 'mvn:0.0.1', 'correct package format version');
+  t.ok(result.package.dependencies['axis:axis']);
+  t.deepEqual(result.package
+    .dependencies['axis:axis']
+    .dependencies['axis:axis-jaxrpc']
+    .dependencies['org.apache.axis:axis-jaxrpc'].version,
+    '1.4',
+    'correct version found');
 });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Currently our scala SnykSbtPlugin script can't handle the new naming for sbt-dependency-graph plugin
which is used on sbt versions 1.4+
We should warn users when they use it in order for them to use the old annotation, so that the new plugin inspect will be used.
