### PR TITLE
feat: ignore single-line comments in plugin search

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ test_matrix: &test_matrix
   matrix:
     parameters:
       node_version:
-        - "10"
         - "12"
         - "14"
+        - "16"
       jdk_version:
         - "8.0.292.j9-adpt"
         - "11.0.11.j9-adpt"

--- a/lib/plugin-search.ts
+++ b/lib/plugin-search.ts
@@ -55,6 +55,11 @@ function sbtFiles(basePath) {
 }
 
 function searchWithFs(filename, word) {
-  const buffer = fs.readFileSync(filename);
+  let buffer = fs.readFileSync(filename, {encoding: 'utf8'});
+
+  // remove single-line and multi-line comments
+  const singleLineCommentPattern = /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm;
+  buffer = buffer.replace(singleLineCommentPattern, '');
+
   return buffer.indexOf(word) > -1;
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
     "tslint": "5.16.0",
-    "typescript": "3.9.7"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/test/fixtures/multi-line-comments/build.sbt
+++ b/test/fixtures/multi-line-comments/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / organization := "com.example"
+
+lazy val hello = (project in file("."))
+  .settings(
+    name := "Hello",
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.2", 
+    libraryDependencies += "com.eed3si9n" %% "gigahorse-okhttp" % "0.5.0",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.7" % Test,
+)

--- a/test/fixtures/multi-line-comments/project/Dependencies.scala
+++ b/test/fixtures/multi-line-comments/project/Dependencies.scala
@@ -1,0 +1,5 @@
+import sbt._
+
+object Dependencies {
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+}

--- a/test/fixtures/multi-line-comments/project/build.properties
+++ b/test/fixtures/multi-line-comments/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.7

--- a/test/fixtures/multi-line-comments/project/site.sbt
+++ b/test/fixtures/multi-line-comments/project/site.sbt
@@ -1,0 +1,13 @@
+/* addDependencyTreePlugin
+hello, 
+this is the comment that we want to ignore -> addDependencyTreePlugin <- Did it work?
+we shouldn't be taking these words into account (addDependencyTreePlugin)
+*/
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2") /* addDependencyTreePlugin
+
+         //// addDependencyTreePlugin
+*/
+"http://nothing-to-see.com/uh-oh" /* addDependencyTreePlugin */
+"http://nothing-to-see.com/uh-oh" /* addDependencyTreePlugin 
+addDependencyTreePlugin
+*/

--- a/test/fixtures/multi-line-comments/src/main/scala/example/Hello.scala
+++ b/test/fixtures/multi-line-comments/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/test/fixtures/multi-line-comments/src/test/scala/example/HelloSpec.scala
+++ b/test/fixtures/multi-line-comments/src/test/scala/example/HelloSpec.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest._
+
+class HelloSpec extends FlatSpec with Matchers {
+  "The Hello object" should "say hello" in {
+    Hello.greeting shouldEqual "hello"
+  }
+}

--- a/test/fixtures/single-line-comments/build.sbt
+++ b/test/fixtures/single-line-comments/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / organization := "com.example"
+
+lazy val hello = (project in file("."))
+  .settings(
+    name := "Hello",
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.2", 
+    libraryDependencies += "com.eed3si9n" %% "gigahorse-okhttp" % "0.5.0",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.7" % Test,
+)

--- a/test/fixtures/single-line-comments/project/Dependencies.scala
+++ b/test/fixtures/single-line-comments/project/Dependencies.scala
@@ -1,0 +1,5 @@
+import sbt._
+
+object Dependencies {
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+}

--- a/test/fixtures/single-line-comments/project/build.properties
+++ b/test/fixtures/single-line-comments/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.7

--- a/test/fixtures/single-line-comments/project/site.sbt
+++ b/test/fixtures/single-line-comments/project/site.sbt
@@ -1,0 +1,5 @@
+// hello, this is the comment that we want to ignore -> addDependencyTreePlugin <- Did it work?
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2") // addDependencyTreePlugin
+         //// addDependencyTreePlugin
+
+"http://nothing-to-see.com/uh-oh" //addDependencyTreePlugin

--- a/test/fixtures/single-line-comments/src/main/scala/example/Hello.scala
+++ b/test/fixtures/single-line-comments/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/test/fixtures/single-line-comments/src/test/scala/example/HelloSpec.scala
+++ b/test/fixtures/single-line-comments/src/test/scala/example/HelloSpec.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest._
+
+class HelloSpec extends FlatSpec with Matchers {
+  "The Hello object" should "say hello" in {
+    Hello.greeting shouldEqual "hello"
+  }
+}

--- a/test/functional/plugin-search.spec.ts
+++ b/test/functional/plugin-search.spec.ts
@@ -24,6 +24,18 @@ describe('plugin-search test', () => {
         const received = await isPluginInstalled(root, targetFile, 'will.not.find')
         expect(received).toBe(false);
       });
+      it('returns false if the project directory has sbt file with plugin name in a single-line comment', async () => {
+        const root = path.join(__dirname, '..', 'fixtures');
+        const targetFile = path.join('single-line-comments', 'build.sbt');
+        const received = await isPluginInstalled(root, targetFile, 'addDependencyTreePlugin')
+        expect(received).toBe(false);
+      });
+      it('returns false if the project directory has sbt file with plugin name in a multi-line comment', async () => {
+        const root = path.join(__dirname, '..', 'fixtures');
+        const targetFile = path.join('multi-line-comments', 'build.sbt');
+        const received = await isPluginInstalled(root, targetFile, 'addDependencyTreePlugin')
+        expect(received).toBe(false);
+      });
     });
     describe('in local project/project folder', () => {
       it('returns true if the project/project directory has sbt file with given plugin name', async () => {

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -104,7 +104,7 @@ test('run inspect() with commented out coursier on 0.13', async (t) => {
   const result: any = await plugin.inspect(path.join(
     __dirname, '..', 'fixtures', 'testproj-faux-coursier-0.13'),
     'build.sbt', {});
-  t.equal(result.plugin.name, 'bundled:sbt', 'correct handler');
+  t.equal(result.plugin.name, 'snyk:sbt', 'correct handler');
   // TODO: fix to get the project name from build.sbt
   // t.equal(result.package.version, '0.1.0-SNAPSHOT');
   t.match(result.package.name, 'hello');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
       "allowJs": true,
       "sourceMap": true,
       "strict": true,
+      "useUnknownInCatchVariables": false,
       // "declaration": true,
       "importHelpers": true,
       "noImplicitAny": false // Needed to compile tap and ansi-escapes


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This change changes the plugin search so that it will ignore single-line comments. Includes an accompanying test fixture and test.
Upgraded the version of Typescript to address some type issues on master which possibly appeared over time due to not including a lock file combined with minor-version bumps in our installed dependencies.

#### Limitation
The limitation of the comment matching is that it requires a space between the first `/` of a comment and any preceding code on the same line. e.g:
This -> `some('code') //comment` will have comments removed correctly, resulting in -> `some('code')`
But without the space, this -> `some('code')//comment` will remove the character before the comment, resulting in -> `some('code'`.