### PR TITLE
fix: reduce scala script output size

### DIFF
--- a/scala/SnykSbtPlugin-1.2x.scala
+++ b/scala/SnykSbtPlugin-1.2x.scala
@@ -4,7 +4,7 @@ import net.virtualvoid.sbt.graph.DependencyGraphKeys.moduleGraph
 import net.virtualvoid.sbt.graph.{ DependencyGraphPlugin, ModuleId }
 import sbt._, Keys._
 import sjsonnew.shaded.scalajson.ast._
-import sjsonnew.support.scalajson.unsafe.PrettyPrinter
+import sjsonnew.support.scalajson.unsafe.CompactPrinter
 
 object SnykSbtPlugin extends AutoPlugin {
   val ConfigBlacklist: Set[String] =
@@ -54,7 +54,7 @@ object SnykSbtPlugin extends AutoPlugin {
     Def.task {
       val allProjectDatas = snykExtractProjectData.all(filter).value
       println("Snyk Output Start")
-      println(PrettyPrinter(JObject(allProjectDatas.map {
+      println(CompactPrinter(JObject(allProjectDatas.map {
         case SnykProjectData(projectId, modules, deps) =>
           projectId -> JObject(
             Map(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Reduces the output size of running the SBT task(s) by:
- Replacing pretty printed JSON with ugly printed JSON.
- Setting the task's log level to `warn` to reduce unnecessary noise.

#### Where should the reviewer start?
At the beginning

#### Any background context you want to provide?
Some users scanning large repositories saw `RangeError: Invalid string length` caused by concatenating too much output from the child process into a single string.