### PR TITLE
fix: reduce scala script output size

### DIFF
--- a/scala/SnykSbtPlugin-1.2x.scala
+++ b/scala/SnykSbtPlugin-1.2x.scala
@@ -4,7 +4,7 @@ import net.virtualvoid.sbt.graph.DependencyGraphKeys.moduleGraph
 import net.virtualvoid.sbt.graph.{ DependencyGraphPlugin, ModuleId }
 import sbt._, Keys._
 import sjsonnew.shaded.scalajson.ast._
-import sjsonnew.support.scalajson.unsafe.PrettyPrinter
+import sjsonnew.support.scalajson.unsafe.CompactPrinter
 
 object SnykSbtPlugin extends AutoPlugin {
   val ConfigBlacklist: Set[String] =
@@ -54,7 +54,7 @@ object SnykSbtPlugin extends AutoPlugin {
     Def.task {
       val allProjectDatas = snykExtractProjectData.all(filter).value
       println("Snyk Output Start")
-      println(PrettyPrinter(JObject(allProjectDatas.map {
+      println(CompactPrinter(JObject(allProjectDatas.map {
         case SnykProjectData(projectId, modules, deps) =>
           projectId -> JObject(
             Map(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Replaces pretty printing of JSON deps output from the scala script with ugly printing. This should reduce the size of the output for pluginInspect results.