### PR TITLE
fix: filter out configs where isPublic is false

### DIFF
--- a/scala/SnykSbtPlugin-0.1x.scala
+++ b/scala/SnykSbtPlugin-0.1x.scala
@@ -88,10 +88,8 @@ object SnykSbtPlugin extends AutoPlugin {
 
       val thisProjectId = formatModuleId((moduleGraph in Compile).value.roots.head.id)
       val thisProjectConfigs = thisProject.value.configurations.filterNot { c =>
-        ConfigBlacklist.contains(c.name)
+        ConfigBlacklist.contains(c.name) || !c.isPublic
       }
-      println(">>> Project's configurations after filtering blacklisted:")
-      println(thisProjectConfigs)
       val filter = ScopeFilter(configurations = inConfigurations(thisProjectConfigs: _*))
       val configAndModuleGraph = Def.task {
         val graph = moduleGraph.value

--- a/scala/SnykSbtPlugin-1.2x.scala
+++ b/scala/SnykSbtPlugin-1.2x.scala
@@ -84,15 +84,12 @@ object SnykSbtPlugin extends AutoPlugin {
 
       val thisProjectId      = formatModuleId((Compile / moduleGraph).value.roots.head.id)
       val thisProjectConfigs = thisProject.value.configurations.filterNot { c =>
-        ConfigBlacklist.contains(c.name)
+        ConfigBlacklist.contains(c.name) || !c.isPublic
       }
-      println(">>> Project's configurations after filtering blacklisted:")
-      println(thisProjectConfigs)
       val filter             = ScopeFilter(configurations = inConfigurations(thisProjectConfigs: _*))
       val configAndModuleGraph = Def.task {
         val graph      = moduleGraph.value
         val configName = configuration.value.name
-
         configName -> graph
       }
 


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Fixes `[error] sbt.internal.util.Init$RuntimeUndefined: References to undefined settings at runtime.`  related to `ScopedKey` . [This error seen previously](https://github.com/snyk/snyk-sbt-plugin/issues/57) was solved with a workaround - blacklisting configurations. However, we have discovered that it's not only configurations for a specific framework that are failing. It seems to be caused more generally by configurations that are not public (config.isPublic set to false). We should filter them out. This will allow more users to use plugin inspect rather than fall back to the legacy path.
