### PR TITLE
add `set asciiGraphWidth := 999999999` flag prior to the `dependencyTree` task to ensure no truncation

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -273,8 +273,11 @@ export function buildArgs(
   isCoursierProject?: boolean,
   isOutputGraph?: boolean,
 ) {
-  // force plain output so we don't have to parse colour codes
-  let args = ['-Dsbt.log.noformat=true'];
+  
+  let args = [
+    '-Dsbt.log.noformat=true', // force plain output so we don't have to parse colour codes
+    '\'set asciiGraphWidth := 999999999\'' // to ensure no trunctation with deep dependency trees
+  ];
   if (sbtArgs) {
     args = args.concat(sbtArgs);
   }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
