### PR TITLE
fix: do not accumulate output into a single string

### DIFF
--- a/lib/parse-sbt.ts
+++ b/lib/parse-sbt.ts
@@ -5,8 +5,7 @@ import * as types from './types';
 
 export { parse, parseSbtPluginResults };
 
-function convertStrToTree(dependenciesTextTree) {
-  const lines = dependenciesTextTree.toString().split('\n') || [];
+function convertStrToTree(lines) {
   const newLines = lines
     .map((line) => {
       return line.replace(/\u001b\[0m/g, '');
@@ -37,8 +36,7 @@ function convertStrToTree(dependenciesTextTree) {
   return tree;
 }
 
-function convertCoursierStrToTree(dependenciesTextTree) {
-  const lines = dependenciesTextTree.toString().split('\n') || [];
+function convertCoursierStrToTree(lines) {
   const newLines = lines
     .map((line) => {
       return line.replace(/\u001b\[0m/g, '');
@@ -187,17 +185,17 @@ function parse(text, name, version, isCoursier): DepTree {
 }
 
 function parseSbtPluginResults(
-  sbtOutput: string,
+  sbtOutput: string[],
   packageName: string,
   packageVersion: string,
 ): DepTree {
   // remove all other output
   const outputStart = 'Snyk Output Start';
   const outputEnd = 'Snyk Output End';
-  const sbtProjectOutput = sbtOutput.substring(
-    sbtOutput.indexOf(outputStart) + outputStart.length,
-    sbtOutput.indexOf(outputEnd),
-  );
+  const sbtProjectOutput = sbtOutput.slice(
+    sbtOutput.findIndex(line => line.indexOf(outputStart)!=-1) + 1,
+    sbtOutput.findIndex(line => line.indexOf(outputEnd)!=-1),
+  ).join("\n");
   const sbtOutputJson: types.SbtModulesGraph = JSON.parse(sbtProjectOutput);
 
   if (Object.keys(sbtOutputJson).length === 1) {

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -14,7 +14,7 @@ export const execute = (
   command: string,
   args: string[],
   options: { cwd?: string },
-): Promise<string> => {
+): Promise<string[]> => {
   const spawnOptions: { cwd?: string; shell: boolean } = { shell: true };
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
@@ -23,7 +23,7 @@ export const execute = (
 
   return new Promise((resolve, reject) => {
     const out = {
-      stdout: '',
+      stdout: [''],
       stderr: '',
     };
 
@@ -33,9 +33,9 @@ export const execute = (
     }
 
     proc.stdout.on('data', (data) => {
-      const strData = data.toString();
-      out.stdout = out.stdout + strData;
+      const strData = out.stdout.pop() + data.toString();
       strData.split('\n').forEach((str) => {
+        out.stdout.push(str);
         debugLogging(str);
       });
       if (strData.includes('(q)uit')) {
@@ -63,7 +63,9 @@ export const execute = (
         const errorMessage =
           `>>> command: ${fullCommand} ` +
           (code ? `>>> exit code: ${code} ` : '') +
-          (out.stdout ? `>>> stdout: ${out.stdout} ` : '') +
+          (out.stdout.length
+            ? `>>> stdout: ... ${out.stdout[out.stdout.length - 1]} `
+            : '') +
           (out.stderr ? `>>> stderr: ${out.stderr}` : 'null');
         return reject(new Error(errorMessage));
       }

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -50,7 +50,6 @@ export async function getSbtVersion(
   try {
     const stdout = await subProcess.execute('sbt', ['--version'], {});
     return stdout
-      .split('\n')
       .find((line) => !!line.match(/sbt script version/))!
       .split(':')[1]
       .trim();

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jest-junit": "^12.2.0",
     "prettier": "^2.8.0",
     "ts-jest": "^27.1.4",
-    "ts-node": "^10.2.1",
+    "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
   "dependencies": {

--- a/test/functional/parse-sbt.test.ts
+++ b/test/functional/parse-sbt.test.ts
@@ -18,10 +18,12 @@ function flatten(dependencies: DepTree): string[] {
 }
 
 test('parse `sbt dependencies` output: multi configuration', async () => {
-  const sbtOutput = fs.readFileSync(
-    path.join(__dirname, '..', 'fixtures', 'sbt-dependency-output.txt'),
-    'utf8',
-  );
+  const sbtOutput = fs
+    .readFileSync(
+      path.join(__dirname, '..', 'fixtures', 'sbt-dependency-output.txt'),
+      'utf8',
+    )
+    .split('\n');
   const depTree = parser.parse(sbtOutput, 'testApp', '1.0.1', false);
 
   expect(depTree.name).toBe('testApp');
@@ -48,15 +50,17 @@ test('parse `sbt dependencies` output: multi configuration', async () => {
 });
 
 test('parse `sbt dependencies` output: single configuration', async () => {
-  const sbtOutput = fs.readFileSync(
-    path.join(
-      __dirname,
-      '..',
-      'fixtures',
-      'sbt-single-config-dependency-output.txt',
-    ),
-    'utf8',
-  );
+  const sbtOutput = fs
+    .readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        'fixtures',
+        'sbt-single-config-dependency-output.txt',
+      ),
+      'utf8',
+    )
+    .split('\n');
 
   const depTree = parser.parse(sbtOutput, 'unused', 'unused', false);
 
@@ -90,10 +94,12 @@ test('parse `sbt dependencies` output: single configuration', async () => {
 });
 
 test('parse `sbt dependencies` output: plugin 1.2.8', async () => {
-  const sbtOutput = fs.readFileSync(
-    path.join(__dirname, '..', 'fixtures', 'sbt-plugin-1.2.8-output.txt'),
-    'utf8',
-  );
+  const sbtOutput = fs
+    .readFileSync(
+      path.join(__dirname, '..', 'fixtures', 'sbt-plugin-1.2.8-output.txt'),
+      'utf8',
+    )
+    .split('\n');
   const depTree = parser.parseSbtPluginResults(
     sbtOutput,
     'com.example:hello_2.12',
@@ -114,10 +120,12 @@ test('parse `sbt dependencies` output: plugin 1.2.8', async () => {
 });
 
 test('parse `sbt dependencies` output: plugin 0.13', async () => {
-  const sbtOutput = fs.readFileSync(
-    path.join(__dirname, '..', 'fixtures', 'sbt-plugin-0.13-output.txt'),
-    'utf8',
-  );
+  const sbtOutput = fs
+    .readFileSync(
+      path.join(__dirname, '..', 'fixtures', 'sbt-plugin-0.13-output.txt'),
+      'utf8',
+    )
+    .split('\n');
   const depTree = parser.parseSbtPluginResults(
     sbtOutput,
     'com.example:hello_2.12',

--- a/test/functional/version.spec.ts
+++ b/test/functional/version.spec.ts
@@ -18,10 +18,12 @@ describe('version test', () => {
 
     it('fall back onto sbt --version if checking build.properties fails', async () => {
       const root = path.join(fixtures, 'empty-homdir');
-      jest.spyOn(subProcess, 'execute').mockResolvedValue(`
+      jest.spyOn(subProcess, 'execute').mockResolvedValue(
+        `
 sbt version in this project: 1.5.5
 sbt script version: 1.5.5
-`);
+`.split('\n'),
+      );
       const received = await getSbtVersion(root, '');
       expect(received).toBe('1.5.5');
     });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Removes the transfer of the sbt output as a single string and conversion into an array of strings to allow output larger than ~512mb.

#### Where should the reviewer start?
parseSbtPluginResults()

#### How should this be manually tested?
This can be tested against an sbt project with a lot of modules with the same dependents to exceed 512mb of data.
It is necessary to increase heap sizes for sbt and node to be able to hit the limit:
export SBT_OPTS="-Xmx8G"
export NODE_OPTIONS="--max-old-space-size=8192"

#### Any background context you want to provide?


#### What are the relevant tickets?
This probably relates to [cli sbt issue](https://github.com/snyk/cli/issues/343)

#### Screenshots
Example of a rangeError overflow in the output String:
$ node -e "console.log(process.versions.v8)"
28 9.4.146.26-node.24
29 $ node -e "x=new String();x=x.padStart(1024*1024*499);console.log(x.length)"
30 523239424
31 $ sbt "-Dsbt.log.noformat=true" --sbt-dir ./.sbt --ivy ./.ivy2 --batch "project main_projects" dependencyTree > deps.out
32 $ ls -al deps.out
33 -rw-rw-r-- 1 gitlab-runner gitlab-runner 709106627 Apr 20 07:57 deps.out
34 $ snyk monitor --remote-repo-url=$SNYK_GROUP_NAME $SNYK_EXTRA_OPTIONS -- $SBT_OPTIONS "--batch" '"project main_projects"'
35 Please make sure that the `sbt-dependency-graph` plugin (https://github.com/jrudolph/sbt-dependency-graph) is installed globally or on the current project, and that `sbt "-Dsbt.log.noformat=true" --sbt-dir ./.sbt --ivy ./.ivy2 --batch "project main_projects" dependencyTree` executes successfully on this project.
36 Alternatively you can use `sbt-coursier` for dependency resolution (https://get-coursier.io/docs/sbt-coursier), in which case ensure that the plugin is installed on the current project and that `sbt "-Dsbt.log.noformat=true" --sbt-dir ./.sbt --ivy ./.ivy2 --batch "project main_projects" coursierDependencyTree` executes successfully on this project.
37 For this project we guessed that you are using sbt-dependency-graph.
38 If the problem persists, collect the output of `sbt "-Dsbt.log.noformat=true" --sbt-dir ./.sbt --ivy ./.ivy2 --batch "project main_projects" dependencyTree` or `sbt "-Dsbt.log.noformat=true" --sbt-dir ./.sbt --ivy ./.ivy2 --batch "project main_projects" coursierDependencyTree` and contact support@snyk.io
39 Something unexpected went wrong: RangeError: Invalid string length
40    at Socket.<anonymous> (/usr/local/lib/node_modules/snyk/dist/cli/webpack:/snyk/node_modules/snyk-sbt-plugin/dist/sub-process.js:29:1)
41    at Socket.emit (node:events:513:28)
42    at Socket.emit (node:domain:489:12)
43    at addChunk (node:internal/streams/readable:315:12)
44    at readableAddChunk (node:internal/streams/readable:289:9)
45    at Socket.Readable.push (node:internal/streams/readable:228:10)
46    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
47 Exit code: 2


#### Additional questions
