### PR TITLE
fix: handle edge cases in stdout buffering

### DIFF
--- a/test/functional/parse-sbt.test.ts
+++ b/test/functional/parse-sbt.test.ts
@@ -120,12 +120,10 @@ test('parse `sbt dependencies` output: plugin 1.2.8', async () => {
 });
 
 test('parse `sbt dependencies` output: plugin 0.13', async () => {
-  const sbtOutput = fs
-    .readFileSync(
-      path.join(__dirname, '..', 'fixtures', 'sbt-plugin-0.13-output.txt'),
-      'utf8',
-    )
-    .split('\n');
+  const sbtOutput = fs.readFileSync(
+    path.join(__dirname, '..', 'fixtures', 'sbt-plugin-0.13-output.txt'),
+    'utf8',
+  ).split('\n');
   const depTree = parser.parseSbtPluginResults(
     sbtOutput,
     'com.example:hello_2.12',

--- a/test/functional/version.spec.ts
+++ b/test/functional/version.spec.ts
@@ -18,12 +18,10 @@ describe('version test', () => {
 
     it('fall back onto sbt --version if checking build.properties fails', async () => {
       const root = path.join(fixtures, 'empty-homdir');
-      jest.spyOn(subProcess, 'execute').mockResolvedValue(
-        `
+      jest.spyOn(subProcess, 'execute').mockResolvedValue(`
 sbt version in this project: 1.5.5
 sbt script version: 1.5.5
-`.split('\n'),
-      );
+`.split('\n'));
       const received = await getSbtVersion(root, '');
       expect(received).toBe('1.5.5');
     });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes the tests and edge cases for how node buffers terminal output and large lines. (This
parsing difference was always present for debugging, generating spurious newlines.)

This version should not need to do any extra work rescanning the large json lines of the snyk scala plugin
for newlines nor print anything additional or in duplicate to the debug logging since it buffers each last
line of output until it is complete.

#### Where should the reviewer start?
sub-process.ts line-29 line-37 line-66 shows the processing changes.
The test changes naturally handle that the data is always sent as an array instead
of converted with a split by the parser.

#### How should this be manually tested?


#### Any background context you want to provide?
This is an update to the changes in #131 -> #133

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
