### PR TITLE
Add kanela-runner to the blacklist

### DIFF
--- a/scala/SnykSbtPlugin-0.1x.scala
+++ b/scala/SnykSbtPlugin-0.1x.scala
@@ -10,7 +10,7 @@ import org.json4s._
 
 object SnykSbtPlugin extends AutoPlugin {
   val ConfigBlacklist: Set[String] =
-    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux", "web-assets", "web-plugin", "web-assets-test", "scalafix")
+    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux", "web-assets", "web-plugin", "web-assets-test", "scalafix", "kanela-runner")
 
   case class SnykModuleInfo(version: String, configurations: Set[String])
 

--- a/scala/SnykSbtPlugin-1.2x.scala
+++ b/scala/SnykSbtPlugin-1.2x.scala
@@ -8,7 +8,7 @@ import sjsonnew.support.scalajson.unsafe.CompactPrinter
 
 object SnykSbtPlugin extends AutoPlugin {
   val ConfigBlacklist: Set[String] =
-    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux", "web-assets", "web-plugin", "web-assets-test", "scalafix")
+    Set("windows", "universal", "universal-docs", "debian", "rpm", "universal-src", "docker", "linux", "web-assets", "web-plugin", "web-assets-test", "scalafix", "kanela-runner")
 
   case class SnykModuleInfo(version: String, configurations: Set[String])
   case class SnykProjectData(

--- a/test/fixtures/testproj-play-scala-seed-1.2.8/build.sbt
+++ b/test/fixtures/testproj-play-scala-seed-1.2.8/build.sbt
@@ -3,7 +3,7 @@ organization := "com.example"
 
 version := "1.0-SNAPSHOT"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, JavaAgent)
 
 scalaVersion := "2.13.0"
 

--- a/test/fixtures/testproj-play-scala-seed-1.2.8/project/plugins.sbt
+++ b/test/fixtures/testproj-play-scala-seed-1.2.8/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addSbtPlugin("io.kamon" % "sbt-kanela-runner-play-2.8" % "2.0.14")

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -80,7 +80,7 @@ test('Run inspect() on play-scala-seed 1.2.8 with custom-plugin', async () => {
       .dependencies['com.typesafe.play:play_2.13'].dependencies[
       'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     ].version,
-  ).toBe('2.9.8');
+  ).toBe('2.11.4');
 });
 
 describe('(These tests will fail locally if sbt-dependency-graph plugin is installed globally.) Run inspect() on sbt v.1.7.0 will use legacy inspect ', () => {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds kanela-runner to the blacklist of plugins that cant't be loaded during a snyk tree analysis.
Adds kanela-runner usage to play-scala-seed to demonstrate the issue is fixed.

#### Where should the reviewer start?
SnykSbtPlugin-1.2x.scala

#### How should this be manually tested?

If the changes to tests are run without the new added blacklist entry kanela runner should break the plugin causing a fallback to the legacy dependencyTree scan.

#### Any background context you want to provide?
Using kanela-runner seems to be the only reason the sbt plugin was failing and falling back to the dependencyTree for us after we upgraded to the latest snyk version. While this is independent of #133 fixing this is leads to much faster performance than fixing #133 but #133 would still apply in any other situation where a fallback to dependencyTree happens.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
I'm not sure if the plugin should be modified to more gracefully handle plugins setup like kanela-runner.
I needed to update the version of the dependency being checked to the current version (2.11.4) since this caused
a reanalysis of dependencies, but I'm not sure what caching may apply in the circleci runner.