### PR TITLE
fix: enhance sbt output width

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -284,6 +284,8 @@ export function buildArgs(
   } else if (isCoursierProject) {
     args.push('coursierDependencyTree'); // coursier
   } else {
+    // enhance sbt default output width from 40 chars to the max
+    args.push('set asciiGraphWidth := 999999999');
     args.push('dependencyTree'); // sbt native
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --color --cache 'lib/**/*.{js,ts}'",
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "prepare": "npm run build",
-    "test": "jest --runInBand -b  --testTimeout=100000"
+    "test": "jest --runInBand -b  --testTimeout=200000"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",

--- a/test/functional/sbt-plugin.test.ts
+++ b/test/functional/sbt-plugin.test.ts
@@ -6,6 +6,7 @@ test('check build args with array not coursier', () => {
     '-Dsbt.log.noformat=true',
     '-Paxis',
     '-Pjaxen',
+    'set asciiGraphWidth := 999999999',
     'dependencyTree',
   ]);
 });
@@ -15,6 +16,7 @@ test('check build args with string not coursie', () => {
   expect(result).toEqual([
     '-Dsbt.log.noformat=true',
     '-Paxis -Pjaxen',
+    'set asciiGraphWidth := 999999999',
     'dependencyTree',
   ]);
 });
@@ -61,6 +63,7 @@ test('check build args with string for not coursier and not snykRenderTree', () 
   expect(result).toEqual([
     '-Dsbt.log.noformat=true',
     '-Paxis -Pjaxen',
+    'set asciiGraphWidth := 999999999',
     'dependencyTree',
   ]);
 });


### PR DESCRIPTION
`sbt dependencyTree` has a max output width of 40, and thus truncating the dependency coordinates. Incomplete output rows lead to False Positives (because of missing "evicted by" tag, truncated dependency versions, etc)
Setting `asciiGraphWidth := 999999999` gets us the full untouched report

Reference: https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated