### PR TITLE
chore: unblocking release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ params: &params
   parameters:
     node_version:
       type: string
-      default: '20'
+      default: '20.19.1'
     jdk_version:
       type: string
       default: '8.0.292.j9-adpt'


### PR DESCRIPTION
Last PR [failed](https://github.com/snyk/snyk-sbt-plugin/runs/43526170239) on release due to a bad `cimg/docker` version.