### PR TITLE
fix: remove per line logging from sub-process calls

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -56,7 +56,6 @@ export const execute = (
 
       lines.forEach((str) => {
         out.stdout.push(str);
-        debugLogging(str);
       });
       if (lastLine.includes('(q)uit')) {
         proc.stdin.write('q\n');


### PR DESCRIPTION
Logging each line from a sub-process in sbt can produce massive output
for debugging and doesn't provide value to internal debugging or
  customers. This PR suggests we remove this.

If the subprocess errors though, we should still get debug logs 
