### PR TITLE
fix: don't fail run when there are missing modulegraphs - ignore them and continue

### DIFF
--- a/scala/SnykSbtPlugin-0.1x.scala
+++ b/scala/SnykSbtPlugin-0.1x.scala
@@ -98,8 +98,14 @@ object SnykSbtPlugin extends AutoPlugin {
       // skipped instead of failing the whole task graph with sbt.internal.util.Init$RuntimeUndefined.
       val configAndModuleGraph = Def.task {
         val configName = configuration.value.name
+        val log = streams.value.log
 
-        moduleGraph.?.value.map(graph => configName -> graph)
+        moduleGraph.?.value match {
+          case Some(graph) => Some(configName -> graph)
+          case None =>
+            log.warn(s"[snyk] Skipping configuration '$configName' - no moduleGraph defined")
+            None
+        }
       }
 
       Def.task {

--- a/scala/SnykSbtPlugin-0.1x.scala
+++ b/scala/SnykSbtPlugin-0.1x.scala
@@ -94,15 +94,16 @@ object SnykSbtPlugin extends AutoPlugin {
         ConfigBlacklist.contains(c.name) || !c.isPublic
       }
       val filter = ScopeFilter(configurations = inConfigurations(thisProjectConfigs: _*))
+      // Use `moduleGraph.?` so configurations that don't have `moduleGraph` defined (e.g. user-defined configs) are
+      // skipped instead of failing the whole task graph with sbt.internal.util.Init$RuntimeUndefined.
       val configAndModuleGraph = Def.task {
-        val graph = moduleGraph.value
         val configName = configuration.value.name
 
-        configName -> graph
+        moduleGraph.?.value.map(graph => configName -> graph)
       }
 
       Def.task {
-        val graphs = configAndModuleGraph.all(filter).value
+        val graphs = configAndModuleGraph.all(filter).value.flatten
 
         graphs.foldLeft(SnykProjectData(thisProjectId, Map.empty, Map.empty)) {
           case (projectData, (configName, graph)) =>

--- a/scala/SnykSbtPlugin-1.2x.scala
+++ b/scala/SnykSbtPlugin-1.2x.scala
@@ -94,7 +94,13 @@ object SnykSbtPlugin extends AutoPlugin {
       // skipped instead of failing the whole task graph with sbt.internal.util.Init$RuntimeUndefined.
       val configAndModuleGraph = Def.task {
         val configName = configuration.value.name
-        moduleGraph.?.value.map(graph => configName -> graph)
+        val log        = streams.value.log
+        moduleGraph.?.value match {
+          case Some(graph) => Some(configName -> graph)
+          case None        =>
+            log.warn(s"[snyk] Skipping configuration '$configName' - no moduleGraph defined")
+            None
+        }
       }
 
       Def.task {

--- a/scala/SnykSbtPlugin-1.2x.scala
+++ b/scala/SnykSbtPlugin-1.2x.scala
@@ -90,14 +90,15 @@ object SnykSbtPlugin extends AutoPlugin {
         ConfigBlacklist.contains(c.name) || !c.isPublic
       }
       val filter             = ScopeFilter(configurations = inConfigurations(thisProjectConfigs: _*))
+      // Use `moduleGraph.?` so configurations that don't have `moduleGraph` defined (e.g. user-defined configs) are
+      // skipped instead of failing the whole task graph with sbt.internal.util.Init$RuntimeUndefined.
       val configAndModuleGraph = Def.task {
-        val graph      = moduleGraph.value
         val configName = configuration.value.name
-        configName -> graph
+        moduleGraph.?.value.map(graph => configName -> graph)
       }
 
       Def.task {
-        val graphs = configAndModuleGraph.all(filter).value
+        val graphs = configAndModuleGraph.all(filter).value.flatten
 
         graphs.foldLeft(SnykProjectData(thisProjectId, Map.empty, Map.empty)) {
           case (projectData, (configName, graph)) =>

--- a/test/fixtures/testproj-1.10-custom-config/build.sbt
+++ b/test/fixtures/testproj-1.10-custom-config/build.sbt
@@ -1,0 +1,19 @@
+// Regression fixture with a public, non-standard sbt configuration, specifically missing the `moduleGraph` task.
+//
+// The Protobuf config below is intentionally declared without DependencyTreeSettings so that
+// `Protobuf / moduleGraph` is undefined. The plugin should skip configs missing `moduleGraph` instead of failing the
+// whole task graph.
+lazy val Protobuf = config("protobuf")
+
+lazy val root = (project in file("."))
+  .configs(Protobuf)
+  .settings(
+    inThisBuild(List(
+      organization := "com.example",
+      scalaVersion := "2.12.16",
+      version      := "0.1.0-SNAPSHOT"
+    )),
+    name := "Hello",
+    libraryDependencies += "axis" % "axis" % "1.4",
+    inConfig(Protobuf)(Defaults.configSettings)
+  )

--- a/test/fixtures/testproj-1.10-custom-config/project/build.properties
+++ b/test/fixtures/testproj-1.10-custom-config/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.7

--- a/test/fixtures/testproj-1.10-custom-config/project/plugins.sbt
+++ b/test/fixtures/testproj-1.10-custom-config/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -136,6 +136,19 @@ test('run legacy inspect() on sbt 1.4.0 with sbt-dependency-graph new naming- ad
   expect(result.package.dependencies['axis:axis'].version).toBe('1.4');
 });
 
+test('run inspect() on project with custom non-standard config (missing moduleGraph)', async () => {
+  const result: any = await plugin.inspect(
+    fixtureDir,
+    'testproj-1.10-custom-config/build.sbt',
+    {},
+  );
+
+  // Plugin path should run to completion instead of falling back to legacy `bundled:sbt`.
+  expect(result.plugin.name).toBe('snyk:sbt');
+  expect(result.package.packageFormatVersion).toBe('mvn:0.0.1');
+  expect(result.package.dependencies['axis:axis'].version).toBe('1.4');
+});
+
 test('run inspect() proj with provided 1.7', async () => {
   const result = await plugin.inspect(
     fixtureDir,


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
If configs don't have moduleGraphs defined, the SBT plugin fails the scan. This is a problem when scanning large monorepos from JetBrains IDEs - the IDE bundles all of the submodule configs into one scan, so if any of them is missing a moduleGraph, the whole scan fails.

The fix is to ignore missing moduleGraphs, instead of throwing an exception.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/IDE-1126

#### Screenshots


#### Additional questions
