### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ params: &params
       default: '1.5.5'
     semantic_release_version:
       type: string
-      default: '17'
+      default: '25.0.5'
 
 test_matrix: &test_matrix
   matrix:
@@ -87,7 +87,9 @@ jobs:
           command: npm install
       - run:
           name: Release
-          command: npx semantic-release@<<parameters.semantic_release_version>>
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release@<<parameters.semantic_release_version>>
 
 workflows:
   version: 2
@@ -119,7 +121,10 @@ workflows:
                 - master
       - release:
           name: Release
-          context: nodejs-app-release
+          node_version: '24.18'
+          context:
+            - nodejs-install
+            - github-release
           filters:
             branches:
               only:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ target/
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 coverage
+
+# IDE
+/.idea/
+/.vscode/
+/.cursor/

--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
   "name": "snyk-sbt-plugin",
   "description": "Snyk CLI SBT plugin",
-  "homepage": "https://github.com/snyk/snyk-sbt-plugin",
+  "homepage": "https://github.com/snyk/snyk-sbt-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/snyk/snyk-sbt-plugin/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk/snyk-sbt-plugin"
+    "url": "https://github.com/snyk/snyk-sbt-plugin.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

### What this does

Set up NPM OIDC Trusted Publishing for the package


### Notes for the reviewer
- This package is still used by Snyk products. The repo and the npm package are both public and they will remain this way. 
- Trusted Publishing from CircleCI has been configured. 
- The release group was granted Write access to the repo.


### More information

- [Jira ticket CMPA-552](https://snyksec.atlassian.net/browse/CMPA-552)

